### PR TITLE
[FEATURE] Add additional Layout Templates for 'News' Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ npm-debug.log
 bower_components
 *.sublime-*
 .idea
+Resources/Private/Language/de.BackendLayouts.xlf
+Resources/Private/Language/de.locallang.xlf
+Resources/Private/Language/de.ContentElements.xlf
+Resources/Private/Language/de.StructuredContentElements.xlf

--- a/Configuration/ContentElements/News.pagets
+++ b/Configuration/ContentElements/News.pagets
@@ -1,0 +1,10 @@
+# **********************************************************
+#  EXT:news
+# **********************************************************
+
+tx_news.templateLayouts {
+    1 = 1: Media Objects (list view)
+    2 = 2: Thumbnails (list view)
+    3 = 3: Timeline (list view)
+    4 = 4: Detail view
+}

--- a/Resources/Private/Extensions/News/Layouts/General.html
+++ b/Resources/Private/Extensions/News/Layouts/General.html
@@ -1,0 +1,9 @@
+{namespace n=GeorgRinger\News\ViewHelpers}
+
+<f:if condition="{settings.cssFile}">
+  <n:includeFile path="{settings.cssFile}" />
+</f:if>
+
+<div class="news">
+  <f:render section="content" />
+</div>

--- a/Resources/Private/Extensions/News/Partials/Detail/Bootstrap.html
+++ b/Resources/Private/Extensions/News/Partials/Detail/Bootstrap.html
@@ -1,0 +1,189 @@
+{namespace n=GeorgRinger\News\ViewHelpers}
+<n:format.nothing>
+  <f:if condition="{newsItem.alternativeTitle}">
+    <f:then>
+      <n:titleTag>
+        <n:format.htmlentitiesDecode>{newsItem.alternativeTitle}</n:format.htmlentitiesDecode>
+      </n:titleTag>
+    </f:then>
+    <f:else>
+      <n:titleTag>
+        <n:format.htmlentitiesDecode>{newsItem.title}</n:format.htmlentitiesDecode>
+      </n:titleTag>
+    </f:else>
+  </f:if>
+  <f:render partial="Detail/Opengraph" arguments="{newsItem: newsItem, settings:settings}" />
+</n:format.nothing>
+
+<div class="header">
+  <h3 class="pull-left">{newsItem.title}</h3>
+</div>
+<div class="footer">
+  <p>
+    <!-- date -->
+    <span class="news-list-date">
+      <n:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</n:format.date>
+    </span>
+    <f:if condition="{newsItem.categories}">
+      <!-- categories -->
+      <f:render partial="Category/Items" arguments="{categories:newsItem.categories, settings:settings}" />
+    </f:if>
+    <f:if condition="{newsItem.author}">
+      <!-- author -->
+      <span class="news-list-author">
+        {newsItem.author}
+      </span>
+    </f:if>
+  </p>
+</div>
+<f:if condition="{newsItem.teaser}">
+  <!-- teaser -->
+  <div class="teaser-text">
+    <f:format.html>{newsItem.teaser}</f:format.html>
+  </div>
+</f:if>
+<f:if condition="{newsItem.falMedia}">
+<f:then>
+  <div class="row" style="margin-bottom:20px;">
+    <div class="col-md-4">
+      <!-- image Layout -->
+      <f:render partial="Detail/FalMediaContainer" arguments="{media: newsItem.falMedia, settings:settings}" />
+    </div>
+    <div class="col-md-8">
+      <!-- main text -->
+      <f:if condition="{newsItem.bodytext}">
+        <div class="news-text-wrap">
+          <f:format.html>{newsItem.bodytext}</f:format.html>
+        </div>
+      </f:if>
+    </div>
+  </div>
+</f:then>
+<f:else>
+  <div class="row" style="margin-bottom:20px;">
+    <div class="col-md-12">
+      <!-- main text -->
+      <f:if condition="{newsItem.bodytext}">
+        <div class="news-text-wrap">
+          <f:format.html>{newsItem.bodytext}</f:format.html>
+        </div>
+      </f:if>
+    </div>
+  </div>
+</f:else>
+</f:if>
+<f:if condition="{settings.backPid}">
+  <f:then>
+    <div class="row hidden-print">
+    <div class="col-md-6" style="margin-bottom:20px;">
+      <a onclick="goBack()" class="btn btn-primary hidden-print back"><f:translate key="back-link" /></a>
+    </div>
+
+    <!-- socialmedia -->
+    <f:if condition="{settings.detail.showSocialShareButtons}">
+      <div class="facebook col-md-6" style="margin-bottom:20px;">
+        <div class="like" style="margin-bottom:5px;">
+          <n:social.facebook.like width="409"></n:social.facebook.like>
+        </div>
+        <div class="share" style="margin-bottom:5px;">
+          <n:social.facebook.share>Share</n:social.facebook.share>
+        </div>
+        <div class="twitter">
+          <n:social.twitter>Twitter</n:social.twitter>
+        </div>
+      </div>
+    </f:if>
+    </div>
+  </f:then>
+  <f:else>
+    <f:if condition="{settings.detail.showSocialShareButtons}">
+      <div class="row">
+      <div class="facebook col-md-6 col-md-offset-6">
+        <div class="like">
+          <n:social.facebook.like></n:social.facebook.like>
+        </div>
+        <div class="share">
+          <n:social.facebook.share>Share</n:social.facebook.share>
+        </div>
+        <div class="twitter">
+          <n:social.twitter>Twitter</n:social.twitter>
+        </div>
+      </div>
+      </div>
+    </f:if>
+  </f:else>
+</f:if>
+
+<!-- Integration of the RxShariff-Extension from Heise:
+     If you want this instead of the Original Sharing Configuration, you have to
+      -install the rx_shariff-Extension
+      -deactivate the Html-Code ahead from this part
+      -activate the following three lines. -->
+
+<!-- <div xmlns:rx="http://typo3.org/ns/Reelworx/RxShariff/ViewHelper" class="col-md-8">
+        <rx:shariff services="facebook, twitter, whatsapp, mail, info" enableBackend="true" data="{mail-url: 'mailto:'}" />
+    </div> -->
+
+<!-- Related news records -->
+<div class="row hidden-print">
+  <div class="col-md-12">
+  <f:if condition="{newsItem.allRelatedSorted}">
+    <!-- Related news records -->
+      <ul class="list-group">
+        <li class="list-group-item"><strong><f:translate key="related-news" /></strong></li>
+        <f:for each="{newsItem.allRelatedSorted}" as="related">
+          <li class="list-group-item">
+            <span class="news-related-news-date"><n:format.date format="{f:translate(key:'dateFormat')}">{related.datetime}</n:format.date> &#10072; {related.firstCategory.title}</span><br/>
+            <n:link newsItem="{related}" settings="{settings}">
+              {related.title}
+            </n:link>
+          </li>
+        </f:for>
+      </ul>
+  </f:if>
+    </div>
+</div>
+
+<f:if condition="{newsItem.falRelatedFiles}">
+  <!-- FAL related files -->
+  <div class="news-related news-related-files hidden-print">
+
+    <ul class="list-group">
+      <li class="list-group-item"><strong><f:translate key="related-files" /></strong></li>
+      <f:for each="{newsItem.falRelatedFiles}" as="relatedFile">
+        <li class="list-group-item">
+          <span class="news-related-files-link">
+            <n:format.fileDownload file="{relatedFile.originalResource.publicUrl}" configuration="{settings.relatedFiles.download}">
+              <f:if condition="{relatedFile.originalResource.title}">
+                <f:then>
+                  {relatedFile.originalResource.title}
+                </f:then>
+                <f:else>
+                  {relatedFile.originalResource.name}
+                </f:else>
+              </f:if>
+            </n:format.fileDownload>
+          </span>
+          <span class="news-related-files-size">
+            <n:format.fileSize fileSize="{relatedFile.originalResource.size}" format="{settings.relatedFiles.fileSizeLabels}" />
+          </span>
+        </li>
+      </f:for>
+    </ul>
+  </div>
+</f:if>
+
+<f:if condition="{newsItem.relatedLinks}">
+  <!-- Related links -->
+  <div class="news-related news-related-links hidden-print">
+    <ul class="list-group">
+      <li class="list-group-item"><strong><f:translate key="related-links" /></strong></li>
+      <f:for each="{newsItem.relatedLinks}" as="relatedLink">
+        <li class="list-group-item">
+          <f:link.page pageUid="{relatedLink.uri}" title="{relatedLink.title}" target="{n:targetLink(link:relatedLink.uri)}">{f:if(condition: relatedLink.title, then: relatedLink.title, else: relatedLink.uri)}</f:link.page>
+          <f:if condition="{relatedLink.description}"><span> {relatedLink.description}</span></f:if>
+        </li>
+      </f:for>
+    </ul>
+  </div>
+</f:if>

--- a/Resources/Private/Extensions/News/Partials/Detail/FalMediaImage.html
+++ b/Resources/Private/Extensions/News/Partials/Detail/FalMediaImage.html
@@ -1,0 +1,26 @@
+<div class="mediaelement mediaelement-image">
+	<f:if condition="{settings.lightbox.enable}">
+		<f:then>
+			<f:if condition="{settings.lightbox.slideshow}">
+				<f:then>				
+					<a data-original-title="{mediaElement.description}" data-rel="{settings.detail.media.image.lightbox}" class="gallery" title="{mediaElement.title}" href="{f:uri.image(src:'{mediaElement.uid}' treatIdAsReference:1 maxWidth:'800')}">
+						<f:image class="img-responsive" src="{mediaElement.uid}" treatIdAsReference="1" title="{mediaElement.originalResource.title}" alt="{mediaElement.originalResource.alternative}" maxWidth="{settings.detail.media.image.maxWidth}" maxHeight="{settings.detail.media.image.maxHeight}" />
+					</a>
+				</f:then>
+				<f:else>
+					<a class="gallery" title="{mediaElement.caption}" href="{f:uri.image(src:'{mediaElement.uid}' treatIdAsReference:1 maxWidth:'800')}">
+						<f:image class="img-responsive" src="{mediaElement.uid}" treatIdAsReference="1" title="{mediaElement.originalResource.title}" alt="{mediaElement.originalResource.alternative}" maxWidth="{settings.detail.media.image.maxWidth}" maxHeight="{settings.detail.media.image.maxHeight}" />
+					</a>
+				</f:else>
+			</f:if>
+		</f:then>
+		<f:else>
+			<f:image class="img-responsive" src="{mediaElement.uid}" treatIdAsReference="1" title="{mediaElement.originalResource.title}" alt="{mediaElement.originalResource.alternative}" maxWidth="{settings.detail.media.image.maxWidth}" maxHeight="{settings.detail.media.image.maxHeight}" />
+		</f:else>
+	</f:if>
+</div>
+<f:if condition="{mediaElement.originalResource.description}">
+	<p class="news-img-caption">
+		{mediaElement.originalResource.description}
+	</p>
+</f:if>

--- a/Resources/Private/Extensions/News/Partials/Detail/MediaImage.html
+++ b/Resources/Private/Extensions/News/Partials/Detail/MediaImage.html
@@ -1,0 +1,17 @@
+<div class="mediaelement mediaelement-image">
+	<f:if condition="{settings.detail.media.image.lightbox}">
+		<f:then>
+			<a data-rel="{settings.detail.media.image.lightbox}" title="{mediaElement.caption}" href="{f:uri.image(src:'uploads/tx_news/{mediaElement.content}' maxWidth:'800')}">
+				<f:image class="img-responsive" src="uploads/tx_news/{mediaElement.content}" title="{mediaElement.title}" alt="{mediaElement.alt}" maxWidth="{settings.detail.media.image.maxWidth}" maxHeight="{settings.detail.media.image.maxHeight}" />
+			</a>
+		</f:then>
+		<f:else>
+			<f:image src="uploads/tx_news/{mediaElement.content}" title="{mediaElement.title}" alt="{mediaElement.alt}" maxWidth="{settings.detail.media.image.maxWidth}" maxHeight="{settings.detail.media.image.maxHeight}" />
+		</f:else>
+	</f:if>
+</div>
+<f:if condition="{mediaElement.caption}">
+	<p class="news-img-caption">
+		{mediaElement.caption}
+	</p>
+</f:if>

--- a/Resources/Private/Extensions/News/Partials/List/Item.html
+++ b/Resources/Private/Extensions/News/Partials/List/Item.html
@@ -1,152 +1,152 @@
 {namespace n=GeorgRinger\News\ViewHelpers}<!--
-	=====================
-		Partials/List/Item.html
+  =====================
+    Partials/List/Item.html
 -->
 <div class="article articletype-{newsItem.type}{f:if(condition: newsItem.istopnews, then: ' topnews')}" itemscope="itemscope" itemtype="http://schema.org/Article">
-	<n:excludeDisplayedNews newsItem="{newsItem}"/>
-	<!-- header -->
-	<div class="news-article-header">
-		<h3>
-			<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
-				<span itemprop="headline">{newsItem.title}</span>
-			</n:link>
-		</h3>
-	</div>
+  <n:excludeDisplayedNews newsItem="{newsItem}"/>
+  <!-- header -->
+  <div class="news-article-header">
+    <h3>
+      <n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
+        <span itemprop="headline">{newsItem.title}</span>
+      </n:link>
+    </h3>
+  </div>
 
-	<f:if condition="{newsItem.falMedia}">
-		<!-- fal media preview element -->
-		<f:then>
-			<div class="news-img-wrap">
-				<f:if condition="{newsItem.falMediaPreviews}">
-					<f:then>
-						<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
-							<f:alias map="{mediaElement: newsItem.falMediaPreviews.0}">
-								<f:if condition="{mediaElement.originalResource.type} == 2">
-									<f:image src="{mediaElement.uid}" treatIdAsReference="1" title="{mediaElement.originalResource.title}" alt="{mediaElement.originalResource.alternative}" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
-								</f:if>
-								<f:if condition="{mediaElement.originalResource.type} == 4">
-									<f:render partial="Detail/FalMediaVideo" arguments="{mediaElement: mediaElement}"/>
-								</f:if>
-								<f:if condition="{mediaElement.originalResource.type} == 5">
-									<f:image src="{mediaElement.uid}" treatIdAsReference="1" title="{mediaElement.originalResource.title}" alt="{mediaElement.originalResource.alternative}" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
-								</f:if>
-							</f:alias>
-						</n:link>
-					</f:then>
-					<f:else>
-						<f:if condition="{settings.displayDummyIfNoMedia}">
-							<span class="no-media-element">
-								<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
-									<f:image src="{settings.list.media.dummyImage}" title="" alt="" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
-								</n:link>
-							</span>
-						</f:if>
-					</f:else>
-				</f:if>
+  <f:if condition="{newsItem.falMedia}">
+    <!-- fal media preview element -->
+    <f:then>
+      <div class="news-img-wrap">
+        <f:if condition="{newsItem.falMediaPreviews}">
+          <f:then>
+            <n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
+              <f:alias map="{mediaElement: newsItem.falMediaPreviews.0}">
+                <f:if condition="{mediaElement.originalResource.type} == 2">
+                  <f:image src="{mediaElement.uid}" treatIdAsReference="1" title="{mediaElement.originalResource.title}" alt="{mediaElement.originalResource.alternative}" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
+                </f:if>
+                <f:if condition="{mediaElement.originalResource.type} == 4">
+                  <f:render partial="Detail/FalMediaVideo" arguments="{mediaElement: mediaElement}"/>
+                </f:if>
+                <f:if condition="{mediaElement.originalResource.type} == 5">
+                  <f:image src="{mediaElement.uid}" treatIdAsReference="1" title="{mediaElement.originalResource.title}" alt="{mediaElement.originalResource.alternative}" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
+                </f:if>
+              </f:alias>
+            </n:link>
+          </f:then>
+          <f:else>
+            <f:if condition="{settings.displayDummyIfNoMedia}">
+              <span class="no-media-element">
+                <n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
+                  <f:image src="{settings.list.media.dummyImage}" title="" alt="" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
+                </n:link>
+              </span>
+            </f:if>
+          </f:else>
+        </f:if>
 
-			</div>
-		</f:then>
-		<f:else>
+      </div>
+    </f:then>
+    <f:else>
 
-			<f:if condition="{newsItem.media}">
-				<!-- media preview element -->
-				<f:then>
-					<div class="news-img-wrap">
-						<f:if condition="{newsItem.mediaPreviews}">
-							<f:then>
-								<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
-									<f:alias map="{mediaElement: newsItem.mediaPreviews.0}">
-										<f:if condition="{mediaElement.type} == 0">
-											<f:image src="uploads/tx_news/{mediaElement.image}" title="{mediaElement.title}" alt="{mediaElement.alt}" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
-										</f:if>
-										<f:if condition="{mediaElement.type} == 1">
-											<f:render partial="Detail/MediaVideo" arguments="{mediaElement: mediaElement}"/>
-										</f:if>
-										<f:if condition="{mediaElement.type} == 2">
-											<f:render partial="Detail/MediaHtml" arguments="{mediaElement: mediaElement}"/>
-										</f:if>
-									</f:alias>
-								</n:link>
-							</f:then>
-							<f:else>
-								<f:if condition="{settings.displayDummyIfNoMedia}">
-									<span class="no-media-element">
-										<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
-											<f:image src="{settings.list.media.dummyImage}" title="" alt="" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
-										</n:link>
-									</span>
-								</f:if>
-							</f:else>
-						</f:if>
+      <f:if condition="{newsItem.media}">
+        <!-- media preview element -->
+        <f:then>
+          <div class="news-img-wrap">
+            <f:if condition="{newsItem.mediaPreviews}">
+              <f:then>
+                <n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
+                  <f:alias map="{mediaElement: newsItem.mediaPreviews.0}">
+                    <f:if condition="{mediaElement.type} == 0">
+                      <f:image src="uploads/tx_news/{mediaElement.image}" title="{mediaElement.title}" alt="{mediaElement.alt}" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
+                    </f:if>
+                    <f:if condition="{mediaElement.type} == 1">
+                      <f:render partial="Detail/MediaVideo" arguments="{mediaElement: mediaElement}"/>
+                    </f:if>
+                    <f:if condition="{mediaElement.type} == 2">
+                      <f:render partial="Detail/MediaHtml" arguments="{mediaElement: mediaElement}"/>
+                    </f:if>
+                  </f:alias>
+                </n:link>
+              </f:then>
+              <f:else>
+                <f:if condition="{settings.displayDummyIfNoMedia}">
+                  <span class="no-media-element">
+                    <n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
+                      <f:image src="{settings.list.media.dummyImage}" title="" alt="" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
+                    </n:link>
+                  </span>
+                </f:if>
+              </f:else>
+            </f:if>
 
-					</div>
-				</f:then>
-				<f:else>
-					<f:if condition="{settings.displayDummyIfNoMedia}">
-						<f:then>
-							<div class="news-img-wrap">
-								<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
-									<span class="no-media-element">
-										<f:image src="{settings.list.media.dummyImage}" title="" alt="" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
-									</span>
-								</n:link>
-							</div>
-						</f:then>
-					</f:if>
-				</f:else>
-			</f:if>
+          </div>
+        </f:then>
+        <f:else>
+          <f:if condition="{settings.displayDummyIfNoMedia}">
+            <f:then>
+              <div class="news-img-wrap">
+                <n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
+                  <span class="no-media-element">
+                    <f:image src="{settings.list.media.dummyImage}" title="" alt="" maxWidth="{settings.list.media.image.maxWidth}" maxHeight="{settings.list.media.image.maxHeight}"/>
+                  </span>
+                </n:link>
+              </div>
+            </f:then>
+          </f:if>
+        </f:else>
+      </f:if>
 
-		</f:else>
-	</f:if>
+    </f:else>
+  </f:if>
 
 
-	<!-- teaser -->
-	<div class="teaser-text">
-		<f:if condition="{newsItem.teaser}">
-			<f:then>
-				<span itemprop="description">{newsItem.teaser -> f:format.crop(maxCharacters: '{settings.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</span>
-			</f:then>
-			<f:else>
-				<span itemprop="description">{newsItem.bodytext -> f:format.crop(maxCharacters: '{settings.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</span>
-			</f:else>
-		</f:if>
+  <!-- teaser -->
+  <div class="teaser-text">
+    <f:if condition="{newsItem.teaser}">
+      <f:then>
+        <span itemprop="description">{newsItem.teaser -> f:format.crop(maxCharacters: '{settings.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</span>
+      </f:then>
+      <f:else>
+        <span itemprop="description">{newsItem.bodytext -> f:format.crop(maxCharacters: '{settings.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</span>
+      </f:else>
+    </f:if>
 
-		<n:link newsItem="{newsItem}" settings="{settings}" class="more" title="{newsItem.title}">
-			<f:translate key="more-link"/>
-		</n:link>
-	</div>
+    <n:link newsItem="{newsItem}" settings="{settings}" class="more" title="{newsItem.title}">
+      <f:translate key="more-link"/>
+    </n:link>
+  </div>
 
-	<!-- footer information -->
-	<div class="news-article-footer">
-		<p>
-			<!-- date -->
-			<span class="news-list-date">
-				<time datetime="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}">
-					<f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date>
-					<meta itemprop="datePublished" content="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}" />
-				</time>
-			</span>
+  <!-- footer information -->
+  <div class="news-article-footer">
+    <p>
+      <!-- date -->
+      <span class="news-list-date">
+        <time datetime="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}">
+          <f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date>
+          <meta itemprop="datePublished" content="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}" />
+        </time>
+      </span>
 
-			<f:if condition="{newsItem.firstCategory}">
-				<!-- first category -->
-				<span class="news-list-category">{newsItem.firstCategory.title}</span>
-			</f:if>
+      <f:if condition="{newsItem.firstCategory}">
+        <!-- first category -->
+        <span class="news-list-category">{newsItem.firstCategory.title}</span>
+      </f:if>
 
-			<f:if condition="{newsItem.tags}">
-				<!-- Tags -->
-				<span class="news-list-tags" itemprop="keywords">
-					<f:for each="{newsItem.tags}" as="tag">
-						{tag.title}
-					</f:for>
-				</span>
-			</f:if>
+      <f:if condition="{newsItem.tags}">
+        <!-- Tags -->
+        <span class="news-list-tags" itemprop="keywords">
+          <f:for each="{newsItem.tags}" as="tag">
+            {tag.title}
+          </f:for>
+        </span>
+      </f:if>
 
-			<!-- author -->
-			<f:if condition="{newsItem.author}">
-				<span class="news-list-author">
-					<f:translate key="author" arguments="{0:newsItem.author}"/>
-				</span>
-			</f:if>
-		</p>
-	</div>
+      <!-- author -->
+      <f:if condition="{newsItem.author}">
+        <span class="news-list-author">
+          <f:translate key="author" arguments="{0:newsItem.author}"/>
+        </span>
+      </f:if>
+    </p>
+  </div>
 </div>

--- a/Resources/Private/Extensions/News/Partials/List/MediaObject.html
+++ b/Resources/Private/Extensions/News/Partials/List/MediaObject.html
@@ -1,0 +1,48 @@
+{namespace n=GeorgRinger\News\ViewHelpers}
+<div class="media article articletype-{newsItem.type}{f:if(condition: newsItem.istopnews, then: ' topnews')}">
+	<n:excludeDisplayedNews newsItem="{newsItem}" />
+	<f:if condition="{newsItem.falMediaPreviews}">
+		<f:then>
+			<n:link newsItem="{newsItem}" settings="{settings}" class="pull-left">
+				<f:alias map="{mediaElement: newsItem.falMediaPreviews.0}">
+					<f:if condition="{mediaElement.originalResource.type} == 2">
+						<f:image src="{mediaElement.uid}" treatIdAsReference="1" title="{mediaElement.originalResource.title}" alt="{mediaElement.originalResource.alternative}" width="{settings.mediaObject.width}c-0" height="{settings.mediaObject.height}" />
+					</f:if>
+				</f:alias>
+			</n:link>
+		</f:then>
+		<f:else>
+			<f:if condition="{settings.displayDummyIfNoMedia}">
+				<span class="no-media-element">
+					<n:link newsItem="{newsItem}" settings="{settings}" class="pull-left">
+						<f:image src="{settings.list.media.dummyImage}" title="" alt="" width="{settings.mediaObject.width}" height="{settings.mediaObject.height}" class="img-responsive" />
+					</n:link>
+				</span>
+			</f:if>
+		</f:else>
+	</f:if>
+	<div class="media-body">
+		<span class="newsinfo pull-right text-muted hidden-xs"><small>
+			<f:if condition="{newsItem.firstCategory}">
+				{newsItem.firstCategory.title} |
+			</f:if>
+			<f:format.date format="d.m.Y">{newsItem.datetime}</f:format.date>
+		</small></span>
+		<h4 class="media-heading">
+			<n:link newsItem="{newsItem}" settings="{settings}">
+				{newsItem.title}
+			</n:link>
+		</h4>
+		<f:if condition="{newsItem.teaser}">
+			<f:then>
+				<f:format.html><f:format.crop maxCharacters="{settings.cropMaxCharacters}" respectWordBoundaries="1">{newsItem.teaser}</f:format.crop></f:format.html>
+			</f:then>
+			<f:else>
+				<f:format.html><f:format.crop maxCharacters="{settings.cropMaxCharacters}" respectWordBoundaries="1">{newsItem.bodytext}</f:format.crop></f:format.html>
+			</f:else>
+		</f:if>
+		<n:link newsItem="{newsItem}" settings="{settings}" class="btn pull-right">
+			<f:translate key="more-link" />
+		</n:link>
+	</div>
+</div>

--- a/Resources/Private/Extensions/News/Partials/List/Thumbnail.html
+++ b/Resources/Private/Extensions/News/Partials/List/Thumbnail.html
@@ -1,0 +1,87 @@
+{namespace n=GeorgRinger\News\ViewHelpers}
+{namespace t3kit=T3kit\T3kitExtensionTools\ViewHelpers\Render}
+<!--
+  =====================
+    Partials/List/Thumbnail.html
+-->
+
+<f:for each="<t3kit:newsChunk input='{news}' size='{settings.thumbnail.columns}' />" as="thumbnailrow" iteration="tr">
+  <div class="row tr-{tr.cycle}">
+    <f:for each="{thumbnailrow}" as="newsItem">
+      <n:excludeDisplayedNews newsItem="{newsItem}" />
+      <f:if condition="{settings.thumbnail.columns} == 1">
+        <div class="col-md-12">
+      </f:if>
+      <f:if condition="{settings.thumbnail.columns} == 2">
+        <div class="col-sm-6 col-md-6">
+      </f:if>
+      <f:if condition="{settings.thumbnail.columns} == 3">
+        <div class="col-sm-6 col-md-4">
+      </f:if>
+      <f:if condition="{settings.thumbnail.columns} == 4">
+        <div class="col-sm-6 col-md-3">
+      </f:if>
+      <f:if condition="{settings.thumbnail.columns} > 4">
+        <div class="col-sm-6 col-md-3">
+      </f:if>
+
+      <div class="thumbnail">
+        
+        <!-- date -->
+        <span class="news-list-date">
+          <n:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</n:format.date>
+        </span>
+        
+        <!-- fal media preview element -->
+        <f:if condition="{newsItem.falMediaPreviews}">
+          <f:then>
+            <n:link newsItem="{newsItem}" settings="{settings}">
+              <f:alias map="{mediaElement: newsItem.falMediaPreviews.0}">
+                <f:if condition="{mediaElement.originalResource.type} == 2">
+                  <f:image src="{mediaElement.uid}" treatIdAsReference="1" title="{mediaElement.originalResource.title}" alt="{mediaElement.originalResource.alternative}" width="{settings.thumbnail.width}c-0" height="{settings.thumbnail.height}" />
+                </f:if>
+              </f:alias>
+            </n:link>
+          </f:then>
+          <f:else>
+            <f:if condition="{settings.displayDummyIfNoMedia}">
+              <n:link newsItem="{newsItem}" settings="{settings}">
+                <f:image src="{settings.list.media.dummyImage}" title="" alt="" width="{settings.thumbnail.width}" height="{settings.thumbnail.height}" class="img-responsive" />
+              </n:link>
+            </f:if>
+          </f:else>
+        </f:if>
+        
+        <!-- teaser -->
+        <div class="caption">
+          <h3>{newsItem.title}</h3>
+          <f:if condition="{newsItem.teaser}">
+            <f:then>
+              <f:format.html><f:format.crop maxCharacters="{settings.cropMaxCharacters}" respectWordBoundaries="1">{newsItem.teaser}</f:format.crop></f:format.html>
+            </f:then>
+            <f:else>
+              <f:format.html><f:format.crop maxCharacters="{settings.cropMaxCharacters}" respectWordBoundaries="1">{newsItem.bodytext}</f:format.crop></f:format.html>
+            </f:else>
+          </f:if>
+
+          <n:link newsItem="{newsItem}" settings="{settings}" class="more btn btn-primary">
+            <f:translate key="more-link" />
+          </n:link>
+          
+          <!-- categories -->
+          <span class="glyphicon glyphicon-tags"></span>
+          <f:if condition="{newsItem.categories}">
+            <f:for each="{newsItem.categories}" as="category" iteration="iterator">
+              <div class="news-list-category" title="UID: {category.uid}">{category.title}</div>
+              <f:if condition="{iterator.isLast}">
+                <f:then></f:then>
+                <f:else>,</f:else>
+              </f:if>
+            </f:for>
+          </f:if>
+        </div>
+    </div>
+    </div>
+    </f:for>
+  </div>
+</f:for>

--- a/Resources/Private/Extensions/News/Partials/List/Timeline.html
+++ b/Resources/Private/Extensions/News/Partials/List/Timeline.html
@@ -1,0 +1,91 @@
+{namespace n=GeorgRinger\News\ViewHelpers}
+{namespace t3kit=T3kit\T3kitExtensionTools\ViewHelpers\Render}
+<!--
+  =====================
+    Partials/List/Timeline.html
+-->
+
+<ul class="timeline">
+  <f:for each="<t3kit:newsChunk input='{news}' size='{settings.thumbnail.columns}' />" as="thumbnailrow" iteration="tr">
+    <f:for each="{thumbnailrow}" as="newsItem">
+      <f:cycle values="{0: 'timeline-normal', 1: 'timeline-inverted'}" as="cycle">
+      <li class="{cycle}">
+        <div class="timeline-badge">
+          <!--<a><i class="fa fa-circle" id=""></i></a>-->
+            <!-- date -->
+            <p>
+              <span><n:format.date format="%d">{newsItem.datetime}</n:format.date></span>
+              <small><n:format.date format="%b">{newsItem.datetime}</n:format.date> <n:format.date format="%y">{newsItem.datetime}</n:format.date></small>
+            </p>
+        </div>
+        <div class="timeline-panel">
+          <div class="timeline-heading">
+            
+            <!-- fal media preview element -->
+            <f:if condition="{newsItem.falMediaPreviews}">
+              <f:then>
+                <n:link newsItem="{newsItem}" settings="{settings}">
+                  <f:alias map="{mediaElement: newsItem.falMediaPreviews.0}">
+                    <f:if condition="{mediaElement.originalResource.type} == 2">
+                      <f:image src="{mediaElement.uid}" treatIdAsReference="1" title="{mediaElement.originalResource.title}" alt="{mediaElement.originalResource.alternative}" width="{settings.thumbnail.width}c-0" height="{settings.thumbnail.height}" />
+                    </f:if>
+                  </f:alias>
+                </n:link>
+              </f:then>
+              <f:else>
+                <f:if condition="{settings.displayDummyIfNoMedia}">
+                  <n:link newsItem="{newsItem}" settings="{settings}">
+                    <f:image src="{settings.list.media.dummyImage}" title="" alt="" width="{settings.thumbnail.width}" height="{settings.thumbnail.height}" class="img-responsive" />
+                  </n:link>
+                </f:if>
+              </f:else>
+            </f:if>
+            
+            <!-- teaser -->
+            <div class="caption">
+              <h3>{newsItem.title}</h3>
+            </div>
+          </div>
+          <div class="timeline-body">
+            
+            <f:if condition="{newsItem.teaser}">
+              <f:then>
+                <f:format.html><f:format.crop maxCharacters="{settings.cropMaxCharacters}" respectWordBoundaries="1">{newsItem.teaser}</f:format.crop></f:format.html>
+              </f:then>
+              <f:else>
+                <f:format.html><f:format.crop maxCharacters="{settings.cropMaxCharacters}" respectWordBoundaries="1">{newsItem.bodytext}</f:format.crop></f:format.html>
+              </f:else>
+            </f:if>
+            
+            <n:link newsItem="{newsItem}" settings="{settings}" class="cd-read-more">
+              <f:translate key="more-link" />
+            </n:link>
+            
+          </div>
+          <div class="timeline-footer">
+            
+            <!-- date -->
+            <span class="cd-date">
+              <n:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</n:format.date>
+            </span>
+            
+            <!-- categories -->
+            <div class="footer">
+              <span class="glyphicon glyphicon-tags"></span>
+              <f:if condition="{newsItem.categories}">
+                <f:for each="{newsItem.categories}" as="category" iteration="iterator">
+                  <div class="news-list-category" title="UID: {category.uid}">{category.title}</div>
+                  <f:if condition="{iterator.isLast}">
+                    <f:then></f:then>
+                    <f:else>,</f:else>
+                  </f:if>
+                </f:for>
+              </f:if>
+            </div>
+          </div>
+        </div>
+      </li>
+      </f:cycle>
+    </f:for>
+  </f:for>
+</ul>

--- a/Resources/Private/Extensions/News/Templates/Category/List.html
+++ b/Resources/Private/Extensions/News/Templates/Category/List.html
@@ -1,46 +1,46 @@
 {namespace n=GeorgRinger\News\ViewHelpers}
 <f:layout name="General" />
 <!--
-	=====================
-		Templates/Category/List.html
+  =====================
+    Templates/Category/List.html
 -->
 
 <f:section name="content">
-	<f:if condition="{categories}">
-		<f:then>
+  <f:if condition="{categories}">
+    <f:then>
 
 
-			<f:render section="categoryTree" arguments="{categories:categories,overwriteDemand:overwriteDemand}" />
-		</f:then>
-		<f:else>
-			<f:translate key="list_nocategoriesfound" />
-		</f:else>
-	</f:if>
+      <f:render section="categoryTree" arguments="{categories:categories,overwriteDemand:overwriteDemand}" />
+    </f:then>
+    <f:else>
+      <f:translate key="list_nocategoriesfound" />
+    </f:else>
+  </f:if>
 </f:section>
 
 <f:section name="categoryTree">
-	<div class="news-catecories" >
-	<ul>
-		<f:for each="{categories}" as="category">
-			<li>
-				<f:if condition="{category.item.uid} == {overwriteDemand.categories}">
-					<f:then>
-						<f:link.page title="{category.item.title}" class="active" pageUid="{settings.listPid}"
-							additionalParams="{tx_news_pi1:{overwriteDemand:{categories: category.item.uid}}}">{category.item.title}
-						</f:link.page>
-					</f:then>
-					<f:else>
-						<f:link.page title="{category.item.title}" pageUid="{settings.listPid}"
-							additionalParams="{tx_news_pi1:{overwriteDemand:{categories: category.item.uid}}}">{category.item.title}
-						</f:link.page>
-					</f:else>
-				</f:if>
+  <div class="news-catecories" >
+  <ul>
+    <f:for each="{categories}" as="category">
+      <li>
+        <f:if condition="{category.item.uid} == {overwriteDemand.categories}">
+          <f:then>
+            <f:link.page title="{category.item.title}" class="active" pageUid="{settings.listPid}"
+              additionalParams="{tx_news_pi1:{overwriteDemand:{categories: category.item.uid}}}">{category.item.title}
+            </f:link.page>
+          </f:then>
+          <f:else>
+            <f:link.page title="{category.item.title}" pageUid="{settings.listPid}"
+              additionalParams="{tx_news_pi1:{overwriteDemand:{categories: category.item.uid}}}">{category.item.title}
+            </f:link.page>
+          </f:else>
+        </f:if>
 
-				<f:if condition="{category.children}">
-					<f:render section="categoryTree" arguments="{categories: category.children,overwriteDemand:overwriteDemand}" />
-				</f:if>
-			</li>
-		</f:for>
-	</ul>
-	</div>
+        <f:if condition="{category.children}">
+          <f:render section="categoryTree" arguments="{categories: category.children,overwriteDemand:overwriteDemand}" />
+        </f:if>
+      </li>
+    </f:for>
+  </ul>
+  </div>
 </f:section>

--- a/Resources/Private/Extensions/News/Templates/News/DateMenu.html
+++ b/Resources/Private/Extensions/News/Templates/News/DateMenu.html
@@ -1,33 +1,33 @@
 {namespace n=GeorgRinger\News\ViewHelpers}
 <f:layout name="General" />
 <!--
-	=====================
-		Templates/News/DateMenu.html
+  =====================
+    Templates/News/DateMenu.html
 -->
 
 <f:section name="content">
-	<div class="news-menu-view">
-		<ul>
-			<f:for each="{data.single}" key="year" as="months">
-				<li>
-					{year}
-					<ul>
-						<f:for each="{months}" key="month" as="count">
-							<f:if condition="{0:year, 1:month} == {0:overwriteDemand.year, 1:overwriteDemand.month}">
-								<f:then>
-									<li class="item itemactive">
-								</f:then>
-								<f:else>
-									<li class="item">
-								</f:else>
-							</f:if>
-								<f:link.action pageUid="{listPid}" arguments="{overwriteDemand:{year: year, month: month}}"><f:translate key="month.{month}" /> {year}</f:link.action>
-								({count} <f:translate key="{f:if(condition: '{count} == 1', then: 'entry', else: 'entries')}" />)
-							</li>
-						</f:for>
-					</ul>
-				</li>
-			</f:for>
-		</ul>
-	</div>
+  <div class="news-menu-view">
+    <ul>
+      <f:for each="{data.single}" key="year" as="months">
+        <li>
+          {year}
+          <ul>
+            <f:for each="{months}" key="month" as="count">
+              <f:if condition="{0:year, 1:month} == {0:overwriteDemand.year, 1:overwriteDemand.month}">
+                <f:then>
+                  <li class="item itemactive">
+                </f:then>
+                <f:else>
+                  <li class="item">
+                </f:else>
+              </f:if>
+                <f:link.action pageUid="{listPid}" arguments="{overwriteDemand:{year: year, month: month}}"><f:translate key="month.{month}" /> {year}</f:link.action>
+                ({count} <f:translate key="{f:if(condition: '{count} == 1', then: 'entry', else: 'entries')}" />)
+              </li>
+            </f:for>
+          </ul>
+        </li>
+      </f:for>
+    </ul>
+  </div>
 </f:section>

--- a/Resources/Private/Extensions/News/Templates/News/Detail.html
+++ b/Resources/Private/Extensions/News/Templates/News/Detail.html
@@ -1,218 +1,222 @@
-{namespace n=GeorgRinger\News\ViewHelpers}
+{namespace n=Tx_News_ViewHelpers}
 
 <f:layout name="Detail.html" />
 
 <!--
-	=====================
-		News/Detail.html
+  =====================
+    News/Detail.html
 -->
 
 <f:section name="content">
-	<f:if condition="{newsItem}">
-		<f:then>
-			<n:format.nothing>
-				<f:if condition="{newsItem.alternativeTitle}">
-					<f:then>
-						<n:titleTag>
-							<n:format.htmlentitiesDecode>{newsItem.alternativeTitle}</n:format.htmlentitiesDecode>
-						</n:titleTag>
-					</f:then>
-					<f:else>
-						<n:titleTag>
-							<n:format.htmlentitiesDecode>{newsItem.title}</n:format.htmlentitiesDecode>
-						</n:titleTag>
-					</f:else>
-				</f:if>
-				<f:render partial="Detail/Opengraph" arguments="{newsItem: newsItem, settings:settings}" />
-			</n:format.nothing>
-			<div class="news-article-header">
-				<h3 itemprop="headline">{newsItem.title}</h3>
-			</div>
-			<div class="news-article-footer">
-				<p>
-					<!-- date -->
-					<span class="news-list-date">
-						<time datetime="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}">
-							<f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date>
-							<meta itemprop="datePublished" content="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}" />
-						</time>
-					</span>
+  <f:if condition="{newsItem}">
+    <f:then>
 
-					<f:if condition="{newsItem.categories}">
-						<f:render partial="Category/Items" arguments="{categories:newsItem.categories, settings:settings}" />
-					</f:if>
+  <f:if condition="{settings.templateLayout} == 4">
+    <f:then>
 
-					<f:if condition="{newsItem.tags}">
-						<!-- Tags -->
-						<span class="news-list-tags" itemprop="keywords">
-						<f:for each="{newsItem.tags}" as="tag">
-							{tag.title}
-						</f:for>
-						</span>
-					</f:if>
+      <f:render partial="Detail/Bootstrap" arguments="{newsItem:newsItem, settings:settings}" />
 
-					<f:if condition="{newsItem.author}">
-						<!-- author -->
-						<span class="news-list-author" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-							<f:translate key="author_simple" /> <span itemprop="name">{newsItem.author}</span>
-						</span>
-					</f:if>
-				</p>
-			</div>
+    </f:then>
+    <f:else>
 
-			<f:if condition="{newsItem.teaser}">
-				<!-- teaser -->
-				<div class="teaser-text" itemprop="description">
-					<f:format.html>{newsItem.teaser}</f:format.html>
-				</div>
-			</f:if>
 
-			<f:if condition="{newsItem.contentElements}">
-				<!-- content elements -->
-				<f:cObject typoscriptObjectPath="lib.tx_news.contentElementRendering">{newsItem.contentElementIdList}</f:cObject>
-			</f:if>
+      <n:format.nothing>
+        <f:if condition="{newsItem.alternativeTitle}">
+          <f:then>
+            <n:titleTag>
+              <n:format.htmlentitiesDecode>{newsItem.alternativeTitle}</n:format.htmlentitiesDecode>
+            </n:titleTag>
+          </f:then>
+          <f:else>
+            <n:titleTag>
+              <n:format.htmlentitiesDecode>{newsItem.title}</n:format.htmlentitiesDecode>
+            </n:titleTag>
+          </f:else>
+        </f:if>
+        <f:render partial="Detail/Opengraph" arguments="{newsItem: newsItem, settings:settings}" />
+      </n:format.nothing>
+      <div class="header">
+        <h3>{newsItem.title}</h3>
+      </div>
+      <div class="footer">
+        <p>
+          <!-- date -->
+          <span class="news-list-date">
+            <n:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</n:format.date>
+          </span>
 
-			<f:render partial="Detail/FalMediaContainer" arguments="{media: newsItem.falMedia, settings:settings}" />
-			<f:render partial="Detail/MediaContainer" arguments="{media: newsItem.media, settings:settings}" />
+          <f:if condition="{newsItem.categories}">
+            <f:render partial="Category/Items" arguments="{categories:newsItem.categories, settings:settings}" />
+          </f:if>
 
-			<!-- main text -->
-			<div class="news-text-wrap" itemprop="articleBody">
-				<f:format.html>{newsItem.bodytext}</f:format.html>
-			</div>
+          <f:if condition="{newsItem.tags}">
+            <!-- Tags -->
+            <span class="news-list-tags">
+            <f:for each="{newsItem.tags}" as="tag">
+              {tag.title}
+            </f:for>
+            </span>
+          </f:if>
 
-			<f:if condition="{settings.backPid}">
-				<!-- Link Back -->
-				<div class="news-backlink-wrap">
-					<f:link.page pageUid="{settings.backPid}">
-						<f:translate key="back-link" />
-					</f:link.page>
-				</div>
-			</f:if>
+          <f:if condition="{newsItem.author}">
+            <!-- author -->
+            <span class="news-list-author">
+              <f:translate key="author" arguments="{0:newsItem.author}"></f:translate>
+            </span>
+          </f:if>
+        </p>
+      </div>
 
-			<f:if condition="{settings.detail.showSocialShareButtons}">
-				<div class="facebook">
-					<div class="like">
-						<n:social.facebook.like />
-					</div>
-					<div class="share">
-						<n:social.facebook.share />
-					</div>
-					<div class="twitter">
-						<n:social.twitter>Twitter</n:social.twitter>
-					</div>
-				</div>
-			</f:if>
+      <f:if condition="{newsItem.teaser}">
+        <!-- teaser -->
+        <div class="teaser-text">
+          <f:format.html>{newsItem.teaser}</f:format.html>
+        </div>
+      </f:if>
 
-			<f:if condition="{settings.detail.disqusShortname}">
-				<n:social.disqus newsItem="{newsItem}"
-								 shortName="{settings.detail.disqusShortname}"
-								 link="{n:link(newsItem:newsItem, settings:settings, uriOnly:1, configuration:'{forceAbsoluteUrl:1}')}" />
-			</f:if>
+      <f:if condition="{newsItem.contentElements}">
+        <!-- content elements -->
+        <f:cObject typoscriptObjectPath="lib.tx_news.contentElementRendering">{newsItem.contentElementIdList}</f:cObject>
+      </f:if>
 
-			<!-- related things -->
-			<div class="news-related-wrap">
+      <f:render partial="Detail/FalMediaContainer" arguments="{media: newsItem.falMedia, settings:settings}" />
+      <f:render partial="Detail/MediaContainer" arguments="{media: newsItem.media, settings:settings}" />
 
-				<f:if condition="{newsItem.allRelatedSorted}">
-					<!-- Related news records -->
-					<div class="news-related news-related-news">
-						<h4>
-							<f:translate key="related-news" />
-						</h4>
-						<ul>
-							<f:for each="{newsItem.allRelatedSorted}" as="related">
-								<li>
-									<span class="news-related-news-date"><f:format.date format="{f:translate(key:'dateFormat')}">{related.datetime}</f:format.date></span>
-									<n:link newsItem="{related}" settings="{settings}" title="{related.title}">
-										{related.title}
-									</n:link>
-								</li>
+      <!-- main text -->
+      <div class="news-text-wrap">
+        <f:format.html>{newsItem.bodytext}</f:format.html>
+      </div>
 
-							</f:for>
-						</ul>
-					</div>
-				</f:if>
+      <f:if condition="{settings.backPid}">
+        <!-- Link Back -->
+        <div class="news-backlink-wrap">
+          <f:link.page pageUid="{settings.backPid}">
+            <f:translate key="back-link" />
+          </f:link.page>
+        </div>
+      </f:if>
 
-				<f:if condition="{newsItem.relatedFiles}">
-					<!-- Related files -->
-					<div class="news-related news-related-files">
-						<h4>
-							<f:translate key="related-files" />
-						</h4>
-						<ul>
-							<f:for each="{newsItem.relatedFiles}" as="relatedFile">
-								<li>
-									<span class="news-related-files-link">
-										<n:format.fileDownload file="uploads/tx_news/{relatedFile.file}" configuration="{settings.relatedFiles.download}">
-											<f:if condition="{relatedFile.title}">
-												<f:then>
-													{relatedFile.title}
-												</f:then>
-												<f:else>
-													{relatedFile.file}
-												</f:else>
-											</f:if>
-										</n:format.fileDownload>
-									</span>
-									<span class="news-related-files-size">
-										<n:format.fileSize file="uploads/tx_news/{relatedFile.file}" format="{settings.relatedFiles.fileSizeLabels}" />
-									</span>
-								</li>
-							</f:for>
-						</ul>
-					</div>
-				</f:if>
+      <f:if condition="{settings.detail.showSocialShareButtons}">
+        <div class="facebook">
+          <div class="like">
+            <n:social.facebook.like></n:social.facebook.like>
+          </div>
+          <div class="share">
+            <n:social.facebook.share>Share</n:social.facebook.share>
+          </div>
+          <div class="twitter">
+            <n:social.twitter>Twitter</n:social.twitter>
+          </div>
+        </div>
+      </f:if>
 
-				<f:if condition="{newsItem.falRelatedFiles}">
-					<!-- FAL related files -->
-					<div class="news-related news-related-files">
-						<h4>
-							<f:translate key="related-files" />
-						</h4>
-						<ul>
-							<f:for each="{newsItem.falRelatedFiles}" as="relatedFile">
-								<li>
-									<span class="news-related-files-link">
-										<n:format.fileDownload file="{relatedFile.originalResource.publicUrl}" configuration="{settings.relatedFiles.download}">
-											<f:if condition="{relatedFile.originalResource.title}">
-												<f:comment><!-- Todo: Remove format.raw() if using title/name outside cObject context--></f:comment>
-												<f:then>
-													{relatedFile.originalResource.title -> f:format.raw()}
-												</f:then>
-												<f:else>
-													{relatedFile.originalResource.name -> f:format.raw()}
-												</f:else>
-											</f:if>
-										</n:format.fileDownload>
-									</span>
-									<span class="news-related-files-size">
-										{relatedFile.originalResource.size -> f:format.bytes()}
-									</span>
-								</li>
-							</f:for>
-						</ul>
-					</div>
-				</f:if>
+      <!-- related things -->
+      <div class="news-related-wrap">
 
-				<f:if condition="{newsItem.relatedLinks}">
-					<!-- Related links -->
-					<div class="news-related news-related-links">
-						<h4>
-							<f:translate key="related-links" />
-						</h4>
-						<ul>
-							<f:for each="{newsItem.relatedLinks}" as="relatedLink">
-								<li>
-									<f:link.page pageUid="{relatedLink.uri}" title="{relatedLink.title}" target="{n:targetLink(link:relatedLink.uri)}">{f:if(condition: relatedLink.title, then: relatedLink.title, else: relatedLink.uri)}</f:link.page>
-									<f:if condition="{relatedLink.description}"><span>{relatedLink.description}</span></f:if>
-								</li>
-							</f:for>
-						</ul>
-					</div>
-				</f:if>
-			</div>
-		</f:then>
-		<f:else>
+        <f:if condition="{newsItem.allRelatedSorted}">
+          <!-- Related news records -->
+          <div class="news-related news-related-news">
+            <h4>
+              <f:translate key="related-news" />
+            </h4>
+            <ul>
+              <f:for each="{newsItem.allRelatedSorted}" as="related">
+                <li>
+                  <span class="news-related-news-date"><n:format.date format="{f:translate(key:'dateFormat')}">{related.datetime}</n:format.date></span>
+                  <n:link newsItem="{related}" settings="{settings}">
+                    {related.title}
+                  </n:link>
+                </li>
 
-		</f:else>
-	</f:if>
+              </f:for>
+            </ul>
+          </div>
+        </f:if>
+
+        <f:if condition="{newsItem.relatedFiles}">
+          <!-- Related files -->
+          <div class="news-related news-related-files">
+            <h4>
+              <f:translate key="related-files" />
+            </h4>
+            <ul>
+              <f:for each="{newsItem.relatedFiles}" as="relatedFile">
+                <li>
+                  <span class="news-related-files-link">
+                    <n:format.fileDownload file="uploads/tx_news/{relatedFile.file}" configuration="{settings.relatedFiles.download}">
+                      <f:if condition="{relatedFile.title}">
+                        <f:then>
+                          {relatedFile.title}
+                        </f:then>
+                        <f:else>
+                          {relatedFile.file}
+                        </f:else>
+                      </f:if>
+                    </n:format.fileDownload>
+                  </span>
+                  <span class="news-related-files-size">
+                    <n:format.fileSize file="uploads/tx_news/{relatedFile.file}" format="{settings.relatedFiles.fileSizeLabels}" />
+                  </span>
+                </li>
+              </f:for>
+            </ul>
+          </div>
+        </f:if>
+
+        <f:if condition="{newsItem.falRelatedFiles}">
+          <!-- FAL related files -->
+          <div class="news-related news-related-files">
+            <h4>
+              <f:translate key="related-files" />
+            </h4>
+            <ul>
+              <f:for each="{newsItem.falRelatedFiles}" as="relatedFile">
+                <li>
+                  <span class="news-related-files-link">
+                    <n:format.fileDownload file="{relatedFile.originalResource.publicUrl}" configuration="{settings.relatedFiles.download}">
+                      <f:if condition="{relatedFile.originalResource.title}">
+                        <f:then>
+                          {relatedFile.originalResource.title}
+                        </f:then>
+                        <f:else>
+                          {relatedFile.originalResource.name}
+                        </f:else>
+                      </f:if>
+                    </n:format.fileDownload>
+                  </span>
+                  <span class="news-related-files-size">
+                    <n:format.fileSize fileSize="{relatedFile.originalResource.size}" format="{settings.relatedFiles.fileSizeLabels}" />
+                  </span>
+                </li>
+              </f:for>
+            </ul>
+          </div>
+        </f:if>
+
+        <f:if condition="{newsItem.relatedLinks}">
+          <!-- Related links -->
+          <div class="news-related news-related-links">
+            <h4>
+              <f:translate key="related-links" />
+            </h4>
+            <ul>
+              <f:for each="{newsItem.relatedLinks}" as="relatedLink">
+                <li>
+                  <f:link.page pageUid="{relatedLink.uri}" title="{relatedLink.title}" target="{n:targetLink(link:relatedLink.uri)}">{f:if(condition: relatedLink.title, then: relatedLink.title, else: relatedLink.uri)}</f:link.page>
+                  <f:if condition="{relatedLink.description}"><span>{relatedLink.description}</span></f:if>
+                </li>
+              </f:for>
+            </ul>
+          </div>
+        </f:if>
+      </div>
+
+    </f:else>
+  </f:if>
+
+    </f:then>
+    <f:else>
+
+    </f:else>
+  </f:if>
 </f:section>

--- a/Resources/Private/Extensions/News/Templates/News/List.html
+++ b/Resources/Private/Extensions/News/Templates/News/List.html
@@ -1,34 +1,92 @@
 {namespace n=GeorgRinger\News\ViewHelpers}
 <f:layout name="General" />
 <!--
-	=====================
-		Templates/News/List.html
+  =====================
+    Templates/News/List.html
 -->
-
 <f:section name="content">
-	<f:if condition="{news}">
-		<f:then>
-			<div class="news-list-view">
-				<f:if condition="{settings.hidePagination}">
-					<f:then>
-						<f:for each="{news}" as="newsItem" iteration="iterator">
-							<f:render partial="List/Item" arguments="{newsItem: newsItem,settings:settings,iterator:iterator}" />
-						</f:for>
-					</f:then>
-					<f:else>
-						<n:widget.paginate objects="{news}" as="paginatedNews" configuration="{settings.list.paginate}" initial="{offset:settings.offset,limit:settings.limit}">
-							<f:for each="{paginatedNews}" as="newsItem" iteration="iterator">
-								<f:render partial="List/Item" arguments="{newsItem: newsItem,settings:settings,iterator:iterator}" />
-							</f:for>
-						</n:widget.paginate>
-					</f:else>
-				</f:if>
-			</div>
-		</f:then>
-		<f:else>
-			<div class="no-news-found">
-				<f:translate key="list_nonewsfound" />
-			</div>
-		</f:else>
-	</f:if>
+  <f:if condition="{news}">
+    <f:then>
+      <f:if condition="{settings.templateLayout}">
+        <f:then>
+          <f:if condition="{settings.templateLayout} == 1">
+
+            <div class="news-list-view">
+              <f:if condition="{settings.hidePagination}">
+                <f:then>
+                  <f:for each="{news}" as="newsItem">
+                    <f:render partial="List/MediaObject" arguments="{newsItem: newsItem, settings:settings}" />
+                  </f:for>
+                </f:then>
+                <f:else>
+                  <n:widget.paginate objects="{news}" as="paginatedNews" configuration="{settings.list.paginate}" initial="{offset:settings.offset,limit:settings.limit}">
+                    <f:for each="{paginatedNews}" as="newsItem">
+                      <f:render partial="List/MediaObject" arguments="{newsItem: newsItem, settings:settings}" />
+                    </f:for>
+                  </n:widget.paginate>
+                </f:else>
+              </f:if>
+            </div>
+
+          </f:if>
+          <f:if condition="{settings.templateLayout} == 2">
+
+            <div class="news-list-view">
+              <f:if condition="{settings.hidePagination}">
+                <f:then>
+                  <f:render partial="List/Thumbnail" arguments="{news: news, settings:settings}" />
+                </f:then>
+                <f:else>
+                  <f:render partial="List/Thumbnail" arguments="{news: news, settings:settings}" />
+                </f:else>
+              </f:if>
+            </div>
+
+
+          </f:if>
+          <f:if condition="{settings.templateLayout} == 3">
+
+            <div class="news-list-view">
+              <f:if condition="{settings.hidePagination}">
+                <f:then>
+                  <f:render partial="List/Timeline" arguments="{news: news, settings:settings}" />
+                </f:then>
+                <f:else>
+                  <f:render partial="List/Timeline" arguments="{news: news, settings:settings}" />
+                </f:else>
+              </f:if>
+            </div>
+
+
+          </f:if>
+        </f:then>
+        <f:else>
+
+          <div class="news-list-view">
+            <f:if condition="{settings.hidePagination}">
+              <f:then>
+                <f:for each="{news}" as="newsItem">
+                  <f:render partial="List/Item" arguments="{newsItem: newsItem, settings:settings}" />
+                </f:for>
+              </f:then>
+              <f:else>
+                <n:widget.paginate objects="{news}" as="paginatedNews" configuration="{settings.list.paginate}" initial="{offset:settings.offset,limit:settings.limit}">
+                  <f:for each="{paginatedNews}" as="newsItem">
+                    <f:render partial="List/Item" arguments="{newsItem: newsItem, settings:settings}" />
+                  </f:for>
+                </n:widget.paginate>
+              </f:else>
+            </f:if>
+          </div>
+
+        </f:else>
+      </f:if>
+
+    </f:then>
+    <f:else>
+      <div class="no-news-found">
+        <f:translate key="list_nonewsfound" />
+      </div>
+    </f:else>
+  </f:if>
 </f:section>

--- a/Resources/Private/Extensions/News/Templates/Tag/List.html
+++ b/Resources/Private/Extensions/News/Templates/Tag/List.html
@@ -2,30 +2,30 @@
 <f:layout name="General" />
 
 <!--
-	=====================
-		Templates/Tag/List.html
+  =====================
+    Templates/Tag/List.html
 -->
 
 <f:section name="content">
-	<f:if condition="{tags}">
-		<ul class="news-tags">
-			<f:for each="{tags}" as="tag">
-				<li>
-					<f:if condition="{tag.uid} == {overwriteDemand.tags}">
-						<f:then>
-							<f:link.page title="{tag.title}" class="active" pageUid="{settings.listPid}" additionalParams="{tx_news_pi1:{overwriteDemand:{tags: tag}}}">
-								{tag.title}
-							</f:link.page>
-						</f:then>
-						<f:else>
-							<f:link.page title="{tag.title}" pageUid="{settings.listPid}" additionalParams="{tx_news_pi1:{overwriteDemand:{tags: tag}}}">
-								{tag.title}
-							</f:link.page>
-						</f:else>
-					</f:if>
+  <f:if condition="{tags}">
+    <ul class="news-tags">
+      <f:for each="{tags}" as="tag">
+        <li>
+          <f:if condition="{tag.uid} == {overwriteDemand.tags}">
+            <f:then>
+              <f:link.page title="{tag.title}" class="active" pageUid="{settings.listPid}" additionalParams="{tx_news_pi1:{overwriteDemand:{tags: tag}}}">
+                {tag.title}
+              </f:link.page>
+            </f:then>
+            <f:else>
+              <f:link.page title="{tag.title}" pageUid="{settings.listPid}" additionalParams="{tx_news_pi1:{overwriteDemand:{tags: tag}}}">
+                {tag.title}
+              </f:link.page>
+            </f:else>
+          </f:if>
 
-				</li>
-			</f:for>
-		</ul>
-	</f:if>
+        </li>
+      </f:for>
+    </ul>
+  </f:if>
 </f:section>

--- a/Resources/Private/Extensions/News/TypoScript/constants.ts
+++ b/Resources/Private/Extensions/News/TypoScript/constants.ts
@@ -1,13 +1,19 @@
-plugin.tx_news {
-    view {
-        # cat=plugin.tx_news/file; type=string; label=Path to template root (FE)
-        templateRootPath = EXT:theme_t3kit/Resources/Private/Extensions/News/Templates/
-        # cat=plugin.tx_news/file; type=string; label=Path to template partials (FE)
-        partialRootPath = EXT:theme_t3kit/Resources/Private/Extensions/News/Partials/
-    }
+# **********************************************************
+#  EXT:news
+# **********************************************************
 
-    settings {
-        # cat=plugin.tx_news/file; type=string; label=Path to CSS file
-        cssFile =
-    }
+plugin.tx_news {
+  view {
+    # cat=plugin.tx_news/file; type=string; label=Path to template root (FE)
+    templateRootPath = EXT:theme_t3kit/Resources/Private/Extensions/News/Templates/
+    # cat=plugin.tx_news/file; type=string; label=Path to template partials (FE)
+    partialRootPath = EXT:theme_t3kit/Resources/Private/Extensions/News/Partials/
+    # cat=plugin.tx_news/file; type=string; label=Path to layouts (FE)
+    layoutRootPath = EXT:theme_t3kit/Resources/Private/Extensions/News/Layouts/
+  }
+
+  settings {
+    # cat=plugin.tx_news/file; type=string; label=Path to CSS file
+    cssFile = EXT:theme_t3kit/Resources/Public/Extensions/News/Css/News.css
+  }
 }

--- a/Resources/Private/Extensions/News/TypoScript/setup.ts
+++ b/Resources/Private/Extensions/News/TypoScript/setup.ts
@@ -1,0 +1,25 @@
+# **********************************************************
+#  EXT:news
+# **********************************************************
+
+plugin.tx_news {
+  settings {
+    thumbnail {
+      # 2,3 or 4 columns
+      columns = 2
+      width = 400
+      height = 250
+    }
+    mediaObject {
+      width = 100
+      height = 100
+    }
+
+    lazyload.enable = 0
+    lightbox.enable = 0
+    lightbox.slideshow = 0
+  }
+  _LOCAL_LANG.de {
+    dateFormat = %d. %B %Y
+  }
+}

--- a/Resources/Public/Extensions/News/Css/News.css
+++ b/Resources/Public/Extensions/News/Css/News.css
@@ -1,0 +1,478 @@
+/* Example Style for tx_news */
+
+.mediaelement-video {
+    height: 0;
+    margin: 20px 0;
+    padding-bottom: 56.25%;
+    padding-top: 25px;
+    position: relative;
+}
+.mediaelement-video iframe {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}
+.mediaelement-image {
+    margin-bottom: 10px;
+}
+
+
+.media.article {
+    padding-bottom: 20px;
+    border-bottom: 1px solid #EEEEEE;
+}
+
+.news .clear {
+    clear: both;
+}
+.news .nav ul {
+    display: inline;
+    float: left;
+    margin: 0;
+}
+.news .article {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+}
+
+
+.facebook .list-group-item {
+    border: medium none;
+}
+.news .article h3 {
+    margin-bottom: 0;
+}
+.news .footer {
+    /*border-top: 1px solid #EEEEEE;*/
+    border: none;
+    clear: both;
+    /*margin-top: 15px;*/
+    margin-top: 0;
+    /*padding: 10px 0 0;*/
+    background: none;
+}
+.news .footer p {
+    color: #555555;
+}
+.news .footer span {
+    border-right: 1px solid #DDDDDD;
+    display: inline-block;
+    margin-right: 8px;
+    padding-right: 8px;
+}
+.news .footer span *:last-child {
+    border-right: 0 none;
+}
+.news .footer .news-category a {
+    text-transform: uppercase;
+}
+.news .no-news-found {
+    color: #DB0202;
+    font-style: italic;
+}
+.list-teaserbox {
+    background-color: #CCCCCC;
+    padding-bottom: 15px;
+}
+.news-single .footer {
+    border-bottom: 0 none;
+    border-top: 1px solid #EEEEEE;
+    margin-bottom: 20px;
+    margin-top: 5px;
+    padding: 10px 0 0;
+    border: none;
+}
+.news-single .teaser-text {
+    font-weight: bold;
+}
+.news-text-wrap {
+    margin-bottom: 20px;
+}
+.news-img-caption {
+    color: #888888;
+}
+.news-img-wrap a {
+    margin-bottom: 10px;
+}
+.thumbnail {
+  display: block;
+  padding: 4px;
+  margin-bottom: 20px;
+  line-height: 1.42857143;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  -webkit-transition: border 0.2s ease-in-out;
+  -o-transition: border 0.2s ease-in-out;
+  transition: border 0.2s ease-in-out;
+}
+.thumbnail > img,
+.thumbnail a > img {
+  /*margin-left: auto;*/
+  /*margin-right: auto;*/
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+a.thumbnail:hover,
+a.thumbnail:focus,
+a.thumbnail.active {
+  border-color: #337ab7;
+}
+.thumbnail .caption {
+  padding: 9px;
+  color: #333333;
+}
+.timeline-v1 {
+  padding: 20px 0;
+  list-style: none;
+  /*position: relative;*/
+}
+
+.cd-timeline-content p, .cd-timeline-content .cd-read-more, .cd-timeline-content .cd-date {
+  font-size: 13px;
+  /*font-size: 0.8125rem;*/
+}
+.cd-timeline-content .cd-read-more, .cd-timeline-content .cd-date {
+  display: inline-block;
+}
+.cd-timeline-content .cd-read-more {
+  float: right;
+  /*padding: .8em 1em;*/
+  padding: 6px 12px;
+  background: #acb7c0;
+  color: white;
+  border-radius: 0.25em;
+}
+.no-touch .cd-timeline-content .cd-read-more:hover {
+  background-color: #bac4cb;
+}
+.cd-timeline-content .cd-date {
+  /*float: left;*/
+  padding: .8em 0;
+  opacity: .7;
+}
+@media only screen and (min-width: 1170px) {
+  .cd-timeline-content .cd-read-more {
+    float: left;
+  }
+  .cd-timeline-content .cd-date {
+    position: absolute;
+    width: 100%;
+    left: 122%;
+    top: 6px;
+    font-size: 16px;
+    /*font-size: 1rem;*/
+  }
+  .cd-timeline-block:nth-child(even) .cd-timeline-content .cd-read-more {
+    float: right;
+  }
+  .cd-timeline-block:nth-child(even) .cd-timeline-content .cd-date {
+    left: auto;
+    right: 122%;
+    text-align: right;
+  }
+}
+
+/* -----------------------------------------------
+ * Timeline
+ * --------------------------------------------- */
+ .timeline {
+    list-style: none;
+    padding: 10px 0;
+    position: relative;
+    font-weight: 300;
+    display: inline-block;
+}
+.timeline:before {
+    top: 0;
+    bottom: 0;
+    position: absolute;
+    content:" ";
+    width: 4px;
+    height: 100%;
+    background: #778899;
+    left: 50%;
+    margin-left: -1.5px;
+}
+.timeline > li {
+    margin-bottom: 20px;
+    position: relative;
+    width: 50%;
+    float: left;
+    clear: left;
+}
+.timeline > li:before, .timeline > li:after {
+    content:" ";
+    display: table;
+}
+.timeline > li:after {
+    clear: both;
+}
+.timeline > li:before, .timeline > li:after {
+    content:" ";
+    display: table;
+}
+.timeline > li:after {
+    clear: both;
+}
+.timeline > li.timeline-normal {
+    /*margin-top: 100px;*/
+    margin-bottom: 80px;
+}
+.timeline > li.timeline-normal:first-of-type {
+    margin-top: 0;
+    margin-bottom: 80px;
+}
+.timeline > li > .timeline-panel {
+    width: calc(100% - 38px);
+    width: -moz-calc(100% - 38px);
+    width: -webkit-calc(100% - 38px);
+    float: left;
+    border: 1px solid #778899;
+    /*background: #e9f0f5;*/
+    background: #fcf8e3;
+    position: relative;
+    border-radius: 0.25em;
+    padding: 1em;
+}
+.timeline > li > .timeline-panel:before {
+    position: absolute;
+    top: 26px;
+    right: -14px;
+    display: inline-block;
+    /*border-top: 15px solid transparent;*/
+    /*border-left: 15px solid #dcdcdc;*/
+    /*border-right: 0 solid #dcdcdc;*/
+    /*border-bottom: 15px solid transparent;*/
+    content:" ";
+    border: 7px solid transparent;
+    border-right: 7px solid #778899;
+    height: 0;
+    width: 0;
+    border-color: transparent;
+    border-left-color: #778899;
+}
+.timeline > li > .timeline-panel:after {
+    position: absolute;
+    top: 26px;
+    right: -14px;
+    display: inline-block;
+    /*border-top: 14px solid transparent;*/
+    /*border-left: 14px solid #ffffff;*/
+    /*border-right: 0 solid #ffffff;*/
+    /*border-bottom: 14px solid transparent;*/
+    content:" ";
+}
+/*.timeline > li > .timeline-badge {
+    color: #d7e4ed;
+    width: 36px;
+    height: 36px;
+    line-height: 38px;
+    text-align: center;
+    position: absolute;
+    top: 16px;
+    right: -18px;
+    z-index: 100;
+    background: #f0ca45;
+    border-radius: 50%;
+}*/
+.timeline > li > .timeline-badge {
+    color: #d7e4ed;
+    width: 52px;
+    height: 52px;
+    line-height: 54px;
+    text-align: center;
+    position: absolute;
+    top: 8px;
+    left: 100%;
+    z-index: 100;
+    /*background: #fcf8e3;*/
+    background: #fcf8e3;
+    border-radius: 50%;
+    margin-left: -26px;
+    -webkit-transform: translateZ(0);
+    -webkit-backface-visibility: hidden;
+    box-shadow: 0 0 0 4px #778899;
+}
+.timeline > li.timeline-inverted {
+    /*margin-top: 100px;*/
+    margin-bottom: 80px;
+}
+.timeline > li.timeline-inverted > .timeline-panel {
+    float: right;
+}
+.timeline > li.timeline-inverted > .timeline-panel:before {
+    /*border-left-width: 0;*/
+    /*border-right-width: 15px;*/
+    left: -14px;
+    right: auto;
+    top: 28px;
+    border: 7px solid transparent;
+    border-left: 7px solid #778899;
+    border-color: transparent;
+    border-right-color: #778899;
+}
+.timeline > li.timeline-inverted > .timeline-panel:after {
+    /*border-left-width: 0;*/
+    /*border-right-width: 14px;*/
+    left: -14px;
+    right: auto;
+}
+.timeline-badge > a {
+    color: #288fb4 !important;
+}
+/*.timeline-badge a:hover {
+    color: #dcdcdc !important;
+}*/
+.timeline-badge > .cd-date {
+    color: #288fb4;
+    font-size: 1.2em;
+    font-weight: 500;
+}
+.timeline-badge > p {
+    /*left: 0;*/
+    /*top: 20px;*/
+    /*background: #fff;*/
+    padding: 4px 0;
+    text-align: center;
+    /*position: absolute;*/
+    display: inline-block;
+}
+.timeline-badge > p span {
+    color: #288fb4;
+    display: block;
+    font-size: 1.3em;
+    font-weight: 500;
+    line-height: 1.3em;
+}
+.timeline-badge > p small {
+    color: #288fb4;
+    display: block;
+    font-size: 1em;
+    font-weight: 300;
+    line-height: 1em;
+}
+.timeline-heading {
+    margin-top: 0;
+    color: inherit;
+}
+.timeline-heading h3 {
+    font-weight: 400;
+    /*padding: 0 15px;*/
+    color: #4679bd;
+}
+.timeline-heading > a > img {
+    vertical-align: middle;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
+.timeline-body > p, .timeline-body > ul {
+    /*padding: 10px 15px;*/
+}
+.timeline-body > ul {
+    margin-bottom: 0;
+}
+.timeline-footer {
+    padding: 5px 5px;
+    background-color:#f4f4f4;
+    margin-top: 20px;
+}
+.timeline-footer p { margin-bottom: 0; }
+.timeline-footer > a {
+    cursor: pointer;
+    text-decoration: none;
+}
+.timeline > li.timeline-inverted {
+    float: right;
+    clear: right;
+}
+.timeline > li:nth-child(2) {
+    margin-top: 100px;
+}
+.timeline > li.timeline-inverted > .timeline-badge {
+    left: 0px;
+}
+.no-float {
+    float: none !important;
+}
+@media (max-width: 767px) {
+    ul.timeline {
+        /*position: relative;*/
+        display: inline-block;
+    }
+    ul.timeline:before {
+        left: 24px;
+    }
+    ul.timeline > li, ul.timeline > li.timeline-normal, ul.timeline > li.timeline-normal:first-of-type {
+        margin-bottom: 0px;
+        position: relative;
+        width:100%;
+        float: left;
+        clear: left;
+    }
+    ul.timeline > li > .timeline-panel {
+        width: calc(100% - 54px);
+        width: -moz-calc(100% - 54px);
+        width: -webkit-calc(100% - 54px);
+    }
+    ul.timeline > li > .timeline-badge, ul.timeline > li.timeline-inverted > .timeline-badge {
+        left: 6px;
+        margin-left: 0;
+        top: 8px;
+        width: 36px;
+        height: 36px;
+        line-height: 38px;
+    }
+    .timeline-badge > p span {
+        color: #288fb4;
+        display: block;
+        font-size: 1.6em;
+        font-weight: 500;
+        line-height: 1.6em;
+        margin-top: -3px;
+        margin-bottom: 0.4em;
+    }
+    .timeline-badge > p small {
+        color: #288fb4;
+        display: block;
+        font-size: 1.1em;
+        font-weight: 300;
+        line-height: 1.1em;
+        background: #fff;
+        padding: 5px 0 2px;
+    }
+    ul.timeline > li > .timeline-panel {
+        float: right;
+    }
+    ul.timeline > li > .timeline-panel:before, ul.timeline > li.timeline-inverted > .timeline-panel:before {
+        /*border-left-width: 0;*/
+        /*border-right-width: 15px;*/
+        left: -14px;
+        right: auto;
+        top: 18px;
+        border: 7px solid transparent;
+        border-left: 7px solid #778899;
+        border-color: transparent;
+        border-right-color: #778899;
+    }
+    ul.timeline > li > .timeline-panel:after, ul.timeline > li.timeline-inverted > .timeline-panel:after {
+        border-left-width: 0;
+        border-right-width: 14px;
+        left: -14px;
+        right: auto;
+    }
+    .timeline > li.timeline-inverted {
+        float: left;
+        clear: left;
+        margin-top: 30px;
+        margin-bottom: 30px;
+    }
+    .timeline > li.timeline-inverted > .timeline-badge {
+        left: 28px;
+    }
+}


### PR DESCRIPTION
The changes add some additional News Template Layouts
-List view: Media Objects, Thumbnails, Timeline
-Detail view: Bootstrap with Standard Social Sharing or integration of
rx_shariff (Extension has to be installed manually)

Last week I created a pull request with this features, but there are
some errors in the files (No newline at end of file). Now I hope it
works...

![list view media objects](https://cloud.githubusercontent.com/assets/15846537/11501794/28d9171c-9837-11e5-994e-c1bea5cff188.png)
![list view thumbnails](https://cloud.githubusercontent.com/assets/15846537/11501796/2da55396-9837-11e5-8987-f6ab8e499553.png)
![list view timeline on desktops](https://cloud.githubusercontent.com/assets/15846537/11501800/31159720-9837-11e5-94a3-def4032e8673.png)
![list view timeline on mobiles](https://cloud.githubusercontent.com/assets/15846537/11501801/34eb24d2-9837-11e5-9133-935c048e8f26.png)
