### PR TITLE
[FEATURE] Adding title overrides the filename

### DIFF
--- a/Resources/Private/Templates/FluidStyledContent/Uploads.html
+++ b/Resources/Private/Templates/FluidStyledContent/Uploads.html
@@ -28,7 +28,14 @@
 						<f:if condition="{file.name}">
 							<a href="{file.publicUrl}">
 								<span class="ce-uploads-fileName">
-									{file.name}
+									<f:if condition="{file.properties.title}">
+										<f:then>
+											{file.properties.title}
+										</f:then>
+										<f:else>
+											{file.name}
+										</f:else>
+									</f:if>
 								</span>
 							</a>
 						</f:if>


### PR DESCRIPTION
Sometimes the filenames have underlines or do not have suitable names that should be displayed in frontend. Using the title will override the filename. 
