### PR TITLE
[FIX] Image title of header image is t3kit (Podio bug_44)

### DIFF
--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -1,7 +1,7 @@
 <INCLUDE_TYPOSCRIPT: source="DIR:EXT:theme_t3kit/Configuration/TypoScript/Library" extensions="constantsts">
 
 # Base configuration
-themes.configuration.siteName = t3kit
+themes.configuration.siteName = Home
 themes.languages.default.isoCode = en_GB
 
 


### PR DESCRIPTION
constant themes.configuration.siteName is used only in ../Configuration/TypoScript/Library/lib.header.logo.main.setupts

in case, we change its value, image title of header image (hover logo) will be "Home"
