### PR TITLE
Fixed some errors to allow EXT:news update to 5.2 inside t3kit

### DIFF
--- a/Resources/Private/Extensions/News/Templates/News/DateMenu.html
+++ b/Resources/Private/Extensions/News/Templates/News/DateMenu.html
@@ -23,7 +23,7 @@
                                         </f:comment>
                                         <n:format.nothing>
                                             <n:titleTag>
-                                                <n:format.htmlentitiesDecode><f:cObject typoscriptObjectPath="lib.pageTitle"/> - <f:translate key="month.{month}" /> {year}</n:format.htmlentitiesDecode>
+                                                <f:format.htmlentitiesDecode><f:cObject typoscriptObjectPath="lib.pageTitle"/> - <f:translate key="month.{month}" /> {year}</f:format.htmlentitiesDecode>
                                             </n:titleTag>
                                         </n:format.nothing>
 

--- a/Resources/Private/Extensions/News/Templates/News/Detail.html
+++ b/Resources/Private/Extensions/News/Templates/News/Detail.html
@@ -106,6 +106,7 @@
                 </f:if>
 
                 <f:if condition="{settings.detail.disqusShortname}">
+					<div id="disqus_thread"></div>
                     <n:social.disqus newsItem="{newsItem}"
                                      shortName="{settings.detail.disqusShortname}"
                                      link="{n:link(newsItem:newsItem, settings:settings, uriOnly:1, configuration:'{forceAbsoluteUrl:1}')}" />

--- a/Resources/Private/Extensions/News/Templates/News/Detail.html
+++ b/Resources/Private/Extensions/News/Templates/News/Detail.html
@@ -17,12 +17,12 @@
                     <f:if condition="{newsItem.alternativeTitle}">
                         <f:then>
                             <n:titleTag>
-                                <n:format.htmlentitiesDecode>{newsItem.alternativeTitle}</n:format.htmlentitiesDecode>
+                                <f:format.htmlentitiesDecode>{newsItem.alternativeTitle}</f:format.htmlentitiesDecode>
                             </n:titleTag>
                         </f:then>
                         <f:else>
                             <n:titleTag>
-                                <n:format.htmlentitiesDecode>{newsItem.title}</n:format.htmlentitiesDecode>
+                                <f:format.htmlentitiesDecode>{newsItem.title}</f:format.htmlentitiesDecode>
                             </n:titleTag>
                         </f:else>
                     </f:if>
@@ -75,8 +75,7 @@
                     <f:cObject typoscriptObjectPath="lib.tx_news.contentElementRendering">{newsItem.contentElementIdList}</f:cObject>
                 </f:if>
 
-                <f:render partial="Detail/FalMediaContainer" arguments="{media: newsItem.falMedia, settings:settings}" />
-                <f:render partial="Detail/MediaContainer" arguments="{media: newsItem.media, settings:settings}" />
+				<f:render partial="Detail/FalMediaContainer" arguments="{media: newsItem.falMedia, settings:settings}" />
 
                 <!-- main text -->
                 <div class="news-text-wrap" itemprop="articleBody">
@@ -135,66 +134,28 @@
                         </div>
                     </f:if>
 
-                    <f:if condition="{newsItem.relatedFiles}">
-                        <!-- Related files -->
-                        <div class="news-related news-related-files">
-                            <h4>
-                                <f:translate key="related-files" />
-                            </h4>
-                            <ul>
-                                <f:for each="{newsItem.relatedFiles}" as="relatedFile">
-                                    <li>
-									<span class="news-related-files-link">
-										<n:format.fileDownload file="uploads/tx_news/{relatedFile.file}" configuration="{settings.relatedFiles.download}">
-											<f:if condition="{relatedFile.title}">
-												<f:then>
-													{relatedFile.title}
-												</f:then>
-												<f:else>
-													{relatedFile.file}
-												</f:else>
-											</f:if>
-										</n:format.fileDownload>
-									</span>
-									<span class="news-related-files-size">
-										<n:format.fileSize file="uploads/tx_news/{relatedFile.file}" format="{settings.relatedFiles.fileSizeLabels}" />
-									</span>
-                                    </li>
-                                </f:for>
-                            </ul>
-                        </div>
-                    </f:if>
-
-                    <f:if condition="{newsItem.falRelatedFiles}">
-                        <!-- FAL related files -->
-                        <div class="news-related news-related-files">
-                            <h4>
-                                <f:translate key="related-files" />
-                            </h4>
-                            <ul>
-                                <f:for each="{newsItem.falRelatedFiles}" as="relatedFile">
-                                    <li>
-									<span class="news-related-files-link">
-										<n:format.fileDownload file="{relatedFile.originalResource.publicUrl}" configuration="{settings.relatedFiles.download}">
-											<f:if condition="{relatedFile.originalResource.title}">
-												<f:comment><!-- Todo: Remove format.raw() if using title/name outside cObject context--></f:comment>
-												<f:then>
-													{relatedFile.originalResource.title -> f:format.raw()}
-												</f:then>
-												<f:else>
-													{relatedFile.originalResource.name -> f:format.raw()}
-												</f:else>
-											</f:if>
-										</n:format.fileDownload>
-									</span>
-									<span class="news-related-files-size">
-										{relatedFile.originalResource.size -> f:format.bytes()}
-									</span>
-                                    </li>
-                                </f:for>
-                            </ul>
-                        </div>
-                    </f:if>
+					<f:if condition="{newsItem.falRelatedFiles}">
+						<!-- FAL related files -->
+						<div class="news-related news-related-files">
+							<h4>
+								<f:translate key="related-files" />
+							</h4>
+							<ul>
+								<f:for each="{newsItem.falRelatedFiles}" as="relatedFile">
+									<li>
+										<span class="news-related-files-link">
+											<a href="{relatedFile.originalResource.publicUrl -> f:format.htmlspecialchars()}" target="_blank">
+												{f:if(condition:relatedFile.originalResource.title, then:relatedFile.originalResource.title, else:relatedFile.originalResource.name)}
+											</a>
+										</span>
+										<span class="news-related-files-size">
+											{relatedFile.originalResource.size -> f:format.bytes()}
+										</span>
+									</li>
+								</f:for>
+							</ul>
+						</div>
+					</f:if>
 
                     <f:if condition="{newsItem.relatedLinks}">
                         <!-- Related links -->


### PR DESCRIPTION
DateMenu.html and Detail.html:

n:format.htmlentitiesDecode was wrong. Changed it to f:format.htmlentitiesDecode. Was it removed in EXT:news? Changing it removed the "ops, an error occurred! Code: .." - error.

Detail.html:

Changed it to fit with Detail.html from EXT:news
Add missing disqus div. Otherwise a JavaScript error will apear.
