### PR TITLE
[BUGFIX] Updated composer.json with dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
         }
     },
     "require": {
-        "typo3/cms": ">=6.2.0 <=7.7.99",
-        "typo3-ter/dyncss": ">=0.7.0 <=0.7.99",
+        "typo3/cms": ">=7.5.0 <=7.7.99",
+        "typo3-ter/dyncss": ">=0.7.2 <=0.7.99",
         "typo3-ter/dyncss-less": ">=0.7.0 <=0.7.99",
-        "typo3-themes/themes": ">=7.0.0 <=7.2.99",
-        "t3kit/t3kit-extension-tools": "*",
-        "typo3-ter/gridelements": ">=7.0.0 <=7.2.99"
+        "typo3-themes/themes": ">=7.0.2 <=7.2.99",
+        "t3kit/t3kit-extension-tools": ">=1.0.0 <=1.0.99",
+        "typo3-ter/gridelements": ">=7.0.5 <=7.2.99"
     }
 }


### PR DESCRIPTION
Dependencies in composer were outdated compared to ext_emconf and did not reflect proper support for TYPO3 version and other extensions. This causes confusion for people trying to install it and also shows wrong information on themes website.