### PR TITLE
[FIX] fix w3c validation of LogoCarousel (Podio bug_30)

### DIFF
--- a/Resources/Private/Templates/ContentElements/LogoCarousel.html
+++ b/Resources/Private/Templates/ContentElements/LogoCarousel.html
@@ -41,6 +41,6 @@
 </div>
 
 <f:section name="renderLogo">
-	<img  data-src="<f:uri.image src="{logoUid}" maxWidth="{maxWidth}" maxHeight="{maxHeight}" treatIdAsReference="1" />" class="swiper-lazy img-responsive logo-carousel__img" alt="{alt}" >
+	<img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="<f:uri.image src="{logoUid}" maxWidth="{maxWidth}" maxHeight="{maxHeight}" treatIdAsReference="1" />" class="swiper-lazy img-responsive logo-carousel__img" alt="{alt}" >
 	<div class="swiper-lazy-preloader"></div>
 </f:section>


### PR DESCRIPTION
Temporary URL -> https://validator.w3.org/nu/?doc=https%3A%2F%2Fddmtkugltv.localtunnel.me

I've chosen the smallest transparent gif image (*according to the rates of following sites: http://probablyprogramming.com/2009/03/15/the-tiniest-gif-ever
http://stackoverflow.com/questions/6018611/smallest-data-uri-image-possible-for-a-transparent-image
http://stackoverflow.com/questions/5775469/whats-the-valid-way-to-include-an-image-with-no-src) data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw== 