### PR TITLE
bootstrap slider Crop Images

### DIFF
--- a/Resources/Private/Templates/ContentElements/BootstrapSlider.html
+++ b/Resources/Private/Templates/ContentElements/BootstrapSlider.html
@@ -43,8 +43,7 @@
 	</f:section>
 
 	<f:section name="Image">
-		<f:image src="{image.uid}" treatIdAsReference="1"/>
-
+		<f:image src="{image.uid}" height="{data.imageheight}c" width="{data.imagewidth}c" treatIdAsReference="1"/>
 		<f:if condition="{image.referenceProperties.title}">
 			<f:then>
 				<div class="carousel-caption">


### PR DESCRIPTION
The width / height wasn’t initially working, it’s now cropping the
picture with the values you entered in the content