### PR TITLE
[FEATURE] Simple accordion (Podio feature_34)

### DIFF
--- a/Configuration/GridElements/FlexForms/AccordionContainer.xml
+++ b/Configuration/GridElements/FlexForms/AccordionContainer.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<T3DataStructure>
+		<meta type="array">
+				<langDisable>1</langDisable>
+		</meta>
+	<sheets>
+		<columns>
+			<ROOT type="array">
+				<TCEforms>
+					<sheetTitle>LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:accordion_container.flexform.title</sheetTitle>
+				</TCEforms>
+				<el type="array">
+					<multiselect>
+						<TCEforms>
+							<label>LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:accordion_container.flexform.multiselect</label>
+							<config>
+								<type>check</type>
+								<default></default>
+							</config>
+						</TCEforms>
+					</multiselect>
+					<accordionMode>
+						<TCEforms>
+							<label>LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:accordion_container.flexform.accordionMode</label>
+							<config>
+								<type>select</type>
+								<items type="array">
+									<numIndex index="0" type="array">
+										<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:accordion_container.flexform.accordionMode_firstChildOpen</numIndex>
+										<numIndex index="1">0</numIndex>
+									</numIndex>
+									<numIndex index="1" type="array">
+										<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:accordion_container.flexform.accordionMode_allOpen</numIndex>
+										<numIndex index="1">1</numIndex>
+									</numIndex>
+									<numIndex index="2" type="array">
+										<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:accordion_container.flexform.accordionMode_allClosed</numIndex>
+										<numIndex index="1">2</numIndex>
+									</numIndex>
+								</items>
+							</config>
+						</TCEforms>
+					</accordionMode>
+				</el>
+			</ROOT>
+		</columns>
+			</sheets>
+</T3DataStructure>

--- a/Configuration/GridElements/PageTS/AccordionContainer.pagets
+++ b/Configuration/GridElements/PageTS/AccordionContainer.pagets
@@ -1,0 +1,20 @@
+tx_gridelements.setup.AccordionContainer {
+	title = LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:accordion_container
+	description = LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:accordion_container_description
+	flexformDS = FILE:EXT:theme_t3kit/Configuration/GridElements/FlexForms/AccordionContainer.xml
+	icon = EXT:theme_t3kit/Resources/Public/Icons/GridElements/accordionContainer.svg
+	config {
+		colCount = 1
+		rowCount = 1
+		rows {
+			1 {
+				columns {
+					1 {
+						name = LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:accordionContainer
+						colPos = 0
+					}
+				}
+			}
+		}
+	}
+}

--- a/Configuration/GridElements/TypoScript/AccordionConatiner.setupts
+++ b/Configuration/GridElements/TypoScript/AccordionConatiner.setupts
@@ -1,0 +1,56 @@
+lib.gridelements {
+    AccordionContainer < .defaultGridSetup
+    AccordionContainer {
+        columns.0 {
+            renderObj >
+            renderObj = COA
+            renderObj {
+              20 =< tt_content
+            }
+        }
+
+        cObject = FLUIDTEMPLATE
+        cObject {
+            layoutRootPaths {
+                20 = EXT:fluid_styled_content/Resources/Private/Layouts
+                30 = EXT:theme_t3kit/Resources/Private/Layouts/GridElements
+            }
+            partialRootPaths {
+                20 = EXT:fluid_styled_content/Resources/Private/Partials
+            }
+            file = EXT:theme_t3kit/Resources/Private/Templates/GridElements/AccordionContainer.html
+            dataProcessing {
+                10 = TYPO3\CMS\Frontend\DataProcessing\FilesProcessor
+                10 {
+                    references.fieldName = media
+                }
+                # "inherit" from lib.fluidContent
+                365 < lib.fluidContent.dataProcessing.365
+                375 < lib.fluidContent.dataProcessing.375
+                385 < lib.fluidContent.dataProcessing.385
+                395 < lib.fluidContent.dataProcessing.395
+
+                # extend "wrapper" class mapping only for GridElements
+                365 {
+                    classMappings {
+                        11 = gridelements-example-wrapper-1
+                        12 = gridelements-example-wrapper-2
+                    }
+                }
+
+
+                1910 < lib.fluidContent.dataProcessing.1910
+
+                # extend "layout" class mapping only for GridElements
+                1910 {
+                    classMappings {
+                        11 = gridelements-example-layout-1
+                        12 = gridelements-example-layout-2
+                    }
+                }
+            }
+        }
+    }
+}
+
+tt_content.gridelements_pi1.20.10.setup.AccordionContainer < lib.gridelements.AccordionContainer

--- a/Resources/Private/Language/GridElements.xlf
+++ b/Resources/Private/Language/GridElements.xlf
@@ -257,6 +257,34 @@
               <source>Style of tabs</source>
             </trans-unit>
 
+            <trans-unit id="accordion_container">
+                <source>Accordion Container</source>
+            </trans-unit>
+            <trans-unit id="accordion_container_description">
+                <source>Container with collapsible child elements, which can either be single elements or containers as well</source>
+            </trans-unit>
+            <trans-unit id="accordion_container_content">
+                <source>Accordion content</source>
+            </trans-unit>
+            <trans-unit id="accordion_container.flexform.sheetGeneral">
+                <source>Additional settings</source>
+            </trans-unit>
+            <trans-unit id="accordion_container.flexform.multiselect">
+                <source>Multiple items can be expanded at the same time</source>
+            </trans-unit>
+            <trans-unit id="accordion_container.flexform.accordionMode">
+                <source>Accordion mode</source>
+            </trans-unit>
+            <trans-unit id="accordion_container.flexform.accordionMode_firstChildOpen">
+                <source>First item is expanded at load.</source>
+            </trans-unit>
+            <trans-unit id="accordion_container.flexform.accordionMode_allClosed">
+                <source>All items are collapsed at load.</source>
+            </trans-unit>
+            <trans-unit id="accordion_container.flexform.accordionMode_allOpen">
+                <source>All items are expanded at load.</source>
+            </trans-unit>
+
             <trans-unit id="sliderContainer">
                 <source>Slider container</source>
             </trans-unit>

--- a/Resources/Private/Templates/GridElements/AccordionContainer.html
+++ b/Resources/Private/Templates/GridElements/AccordionContainer.html
@@ -1,0 +1,68 @@
+{namespace theme=KayStrobach\Themes\ViewHelpers}
+<f:layout name="{f:if(condition: data.tx_gridelements_container, then: 'Empty', else: 'HeaderContentFooter')}" />
+<f:section name="content">
+
+				<div class="panel-group" id="group-{f:if(condition: data._LOCALIZED_UID, then: data._LOCALIZED_UID, else: data.uid)}" role="tablist">
+					<f:for each="{data.tx_gridelements_view_children}" as="panel" iteration="panelnumber">
+						<div class="panel panel-default {layoutClass} {alignClass}">
+							<div class="panel-heading" role="tab" id="heading-{panel.uid}">
+			                    <f:if condition="{data.pi_flexform.data.columns.lDEF.accordionMode.vDEF} < 2">
+			                        <f:then>
+			                            <f:if condition="{data.pi_flexform.data.columns.lDEF.accordionMode.vDEF} == 0">
+			                                <f:then>
+												<h4 class="panel-title">
+			                					<a aria-controls="collapse-{panel.uid}" data-toggle="collapse" class="{f:if(condition: '{panelnumber.index} == 0', then: ' ', else: 'collabsed')} {f:if(condition: panel.header, then:'' , else: 'empty')}" {f:if(condition: data.pi_flexform.data.columns.lDEF.multiselect.vDEF, then: '', else: 'data-parent="#group-{f:if(condition: data._LOCALIZED_UID, then: data._LOCALIZED_UID, else: data.uid)}"')} href="#collapse-{panel.uid}" aria-expanded="{f:if(condition: '{panelnumber.index} == 0', then: 'true', else: 'false')}" role="button">
+			                						<f:if condition="{panel.header}"><f:then>{panel.header}</f:then><f:else> </f:else></f:if>
+			                                    </a>
+												</h4>
+			                                </f:then>
+			                                <f:else>
+												<h4 class="panel-title">
+			                                    <a aria-controls="collapse-{panel.uid}" data-toggle="collapse" class="{f:if(condition: panel.header, then:'' , else: 'empty')}" href="#collapse-{panel.uid}" aria-expanded="false" role="button">
+			                                        <f:if condition="{panel.header}"><f:then>{panel.header}</f:then><f:else> </f:else></f:if>
+			                                    </a>
+												</h4>
+			                                </f:else>
+			                            </f:if>
+			                        </f:then>
+			                        <f:else>
+									<h4 class="panel-title">
+			                            <a aria-controls="collapse-{panel.uid}"  data-toggle="collapse" class="collabsed {f:if(condition: panel.header, then:' ' , else: 'empty')}" {f:if(condition: data.pi_flexform.data.columns.lDEF.multiselect.vDEF, then: '', else: 'data-parent="#group-{f:if(condition: data._LOCALIZED_UID, then: data._LOCALIZED_UID, else: data.uid)}"')} href="#collapse-{panel.uid}" aria-expanded="true" role="button">
+			                                <f:if condition="{panel.header}"><f:then>{panel.header}</f:then><f:else> </f:else></f:if>
+			                            </a>
+									</h4>
+			                        </f:else>
+			                    </f:if>
+							</div>
+			                <f:if condition="{data.pi_flexform.data.columns.lDEF.accordionMode.vDEF} == 0">
+			                    <f:then>
+			                    <div id="collapse-{panel.uid}" class="panel-collapse collapse {f:if(condition: '{panelnumber.index} == 0', then: 'in', else: '')}" role="tabpanel" aria-expanded="{f:if(condition: '{panelnumber.index} == 0', then: 'true', else: 'false')}" aria-labelledby="heading-{panel.uid}">
+			                        <div class="panel-body">
+			                            <f:format.raw>{theme:arrayIndex(object: data, index: 'tx_gridelements_view_child_{panel.uid}')}</f:format.raw>
+			                        </div>
+			                    </div>
+			                    </f:then>
+			                    <f:else>
+			                    <f:if condition="{data.pi_flexform.data.columns.lDEF.accordionMode.vDEF} == 1">
+			                        <f:then>
+			                            <div id="collapse-{panel.uid}" class="panel-collapse collapse in" role="tabpanel" aria-expanded="true" aria-labelledby="heading-{panel.uid}">
+			                                <div class="panel-body">
+			                                    <f:format.raw>{theme:arrayIndex(object: data, index: 'tx_gridelements_view_child_{panel.uid}')}</f:format.raw>
+			                                </div>
+			                            </div>
+			                        </f:then>
+			                        <f:else>
+			                            <div id="collapse-{panel.uid}" class="panel-collapse collapse" role="tabpanel" aria-expanded="false" aria-labelledby="heading-{panel.uid}">
+			                                <div class="panel-body">
+			                                    <f:format.raw>{theme:arrayIndex(object: data, index: 'tx_gridelements_view_child_{panel.uid}')}</f:format.raw>
+			                                </div>
+			                            </div>
+			                        </f:else>
+			                    </f:if>
+			                    </f:else>
+			                </f:if>
+			            </div>
+			        </f:for>
+			    </div>
+
+</f:section>

--- a/Resources/Public/Icons/GridElements/accordionContainer.svg
+++ b/Resources/Public/Icons/GridElements/accordionContainer.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Accordion_2_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#D3D3D3;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#999999;}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st3{fill:#FF5335;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;fill:#FF5335;}
+	.st5{fill-rule:evenodd;clip-rule:evenodd;fill:#737373;}
+</style>
+<path class="st0" d="M0,0h100v100H0V0z"/>
+<polygon class="st1" points="100,23 88,10 76,15 12,25 12,90 22.8,100 100,100 "/>
+<g>
+	<rect x="13.5" y="11.5" class="st2" width="73" height="19"/>
+	<path class="st3" d="M85,13v16H15V13H85 M88,10H12v22h76V10L88,10z"/>
+</g>
+<g>
+	<rect x="13.5" y="39.5" class="st2" width="73" height="49"/>
+	<path class="st3" d="M85,41v46H15V41H85 M88,38H12v52h76V38L88,38z"/>
+</g>
+<polygon class="st4" points="29,21 20,15 20,27 "/>
+<rect x="20" y="56" class="st5" width="60" height="4"/>
+<rect x="20" y="66" class="st5" width="60" height="4"/>
+<rect x="20.1" y="76" class="st5" width="48.9" height="4"/>
+<polygon class="st4" points="26,53 32,44 20,44 "/>
+</svg>


### PR DESCRIPTION
I've used {namespace theme=KayStrobach\Themes\ViewHelpers} according to the book* in odrer to have the data ({theme:arrayIndex(object: data, index: 'tx_gridelements_view_child_{panel.uid}')})

https://books.google.com.ua/books?id=dYwdCAAAQBAJ&pg=PA126&lpg=PA126&dq=theme:arrayIndex(object:+typo3+theming+und&source=bl&ots=Qmn9_l29Tr&sig=EixZVomPkr1RSJylPHnp2s292pc&hl=uk&sa=X&ved=0ahUKEwiE1JzTw4LRAhXD_iwKHRrXALIQ6AEILDAC#v=onepage&q=theme%3AarrayIndex(object%3A%20typo3%20theming%20und&f=false
(page 126 + 138)

weil Fluid selbst nur mit numerischen Array-Keys umgehen kann, nicht aber mit assoziativen Arrays, deren Schlüssel aus Zeichenketten bestehen, kommt hier der VewHelper arrayIndex zum Einsatz. Die Aufgabe dieses ViewHelpers ist es, die UID eines Elements zu ermitteln und den dazu passenden vorgerenderten HTML-Inhalt auszugeben. Für das Element mit der UID 123 wäre der Inhalt beispielsweise über den Schlüssel tx_gridelements_view_child_123 zu erreichen

translation: Because fluid itself can only deal with numeric array keys, but not with associative arrays whose keys consist of character strings, the VewHelper arrayIndex is used here. The task of this viewHelp is to determine the UID of an element and to output the appropriate pre-rendered HTML content. For the element with the UID 123, the content would, for example, be reached using the key tx_gridelements_view_child_123