### PR TITLE
[FEATURE] a lot of whitespace in markup output (Podio feature_47)

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -42,5 +42,9 @@ lib.fluidContent {
 <INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Resources/Private/Extensions/seo_basics/TypoScript/setup.ts">
 [global]
 
+[userFunc = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('min')]
+<INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Resources/Private/Extensions/Min/TypoScript/setup.ts">
+[global]
+
 # Include setupTS files from fileadmin/templates/Configuration/TypoScript
 <INCLUDE_TYPOSCRIPT: source="DIR:fileadmin/templates/Configuration/TypoScript/" extensions="setupts">

--- a/Resources/Private/Extensions/Min/TypoScript/setup.ts
+++ b/Resources/Private/Extensions/Min/TypoScript/setup.ts
@@ -1,0 +1,18 @@
+plugin.tx_min.tinysource {
+	enable = 1
+	head {
+		stripTabs = 0
+		stripNewLines = 0
+		stripDoubleSpaces = 1
+		stripTwoLinesToOne = 1
+	}
+	body {
+		stripComments = 0
+		stripTabs = 1
+		stripNewLines = 0
+		stripDoubleSpaces = 1
+		stripTwoLinesToOne = 1
+		preventStripOfSearchComment = 1
+	}
+	oneLineMode = 1
+}


### PR DESCRIPTION
Hi @jozefspisiak

I installed Minifier extension to remove the white-space in markup
and it has some options to config to make the better markup but it still lack option to make beauty markup.
So I config it remove all space and tab, see in attach files Image 1, Image 2
Do you have any suggestions?
Is it fine for you?

cc: @laurisaarni, @yosokus, @chantheoun