### PR TITLE
[FIX] Replace space character in telephone number of href to have valid HTML.

### DIFF
--- a/Configuration/TypoScript/Library/lib.contacts.phone.setupts
+++ b/Configuration/TypoScript/Library/lib.contacts.phone.setupts
@@ -1,0 +1,11 @@
+# Replace space character in telephone number of href to have valid HTML.
+lib.contacts.phone = TEXT
+lib.contacts.phone {
+  value = {$themes.configuration.contacts.phone}
+  stdWrap.replacement {
+    10 {
+      search.char = 32
+      replace = -
+    }
+  }
+}

--- a/Resources/Private/Partials/Header/Header.html
+++ b/Resources/Private/Partials/Header/Header.html
@@ -22,7 +22,7 @@
 						<div class="header-top__contact-tel">
 							<span class="icons icon-t3-mobile"></span>
 							<span class="header-top__contact-tel-title"><f:translate key="callUs_label" /></span>
-							<a class="header-top__contact-tel-link" href="tel:{theme:constant(constant: 'themes.configuration.contacts.phone')}">tel:{theme:constant(constant: 'themes.configuration.contacts.phone')}</a>
+							<a class="header-top__contact-tel-link" href="tel:{f:cObject(typoscriptObjectPath: 'lib.contacts.phone')}">tel:{theme:constant(constant: 'themes.configuration.contacts.phone')}</a>
 						</div>
 						<div class="header-top__contact-email">
 							<span class="icons icon-t3-mail"></span>

--- a/Resources/Private/Templates/ContentElements/Contacts.html
+++ b/Resources/Private/Templates/ContentElements/Contacts.html
@@ -6,7 +6,7 @@
 <!-- theme_t3kit: Templates/ContentElements/Contacts.html [begin] -->
 
 	<ul class="nav contact-links" >
-		<li><p><span class="icons icon-t3-mobile"></span><span><f:translate key="callUs_label" extensionName="themes"/></span> <a href="tel:{theme:constant(constant: 'themes.configuration.contacts.phone')}"><f:translate key="callUsTel_label" />{theme:constant(constant: 'themes.configuration.contacts.phone')}</a></p></li>
+		<li><p><span class="icons icon-t3-mobile"></span><span><f:translate key="callUs_label" extensionName="themes"/></span> <a href="tel:{f:cObject(typoscriptObjectPath: 'lib.contacts.phone')}"><f:translate key="callUsTel_label" />{theme:constant(constant: 'themes.configuration.contacts.phone')}</a></p></li>
 		<li><p><span class="icons icon-t3-mail"></span><span><f:translate key="emailUs_label" extensionName="themes"/></span> <f:link.email email="{theme:constant(constant: 'themes.configuration.contacts.email')}" /></p></li>
 	</ul>
 


### PR DESCRIPTION
Replace space character in contacts telephone number only in href to have valid HTML.