### PR TITLE
[TASK] Set config.sendCacheHeaders to 1 (see #145)

### DIFF
--- a/Configuration/TypoScript/Library/config.setupts
+++ b/Configuration/TypoScript/Library/config.setupts
@@ -15,6 +15,7 @@ config {
     spamProtectEmailAddresses_atSubst = {$themes.configuration.spamProtectEmailAddresses.atSubst}
     spamProtectEmailAddresses_lastDotSubst = {$themes.configuration.spamProtectEmailAddresses.lastDotSubst}
     headerComment = {$themes.configuration.headerComment}
+    sendCacheHeaders = 1
 }
 
 


### PR DESCRIPTION
After this commit the response headers should change from (only the relevant here):
Cache-Control:max-age=0
Content-Type:text/html; charset=utf-8
Date:Mon, 03 Apr 2017 07:05:48 GMT
Expires:Mon, 03 Apr 2017 07:05:48 GMT

To:
Cache-Control:max-age=86400
Content-Type:text/html; charset=utf-8
Date:Mon, 03 Apr 2017 07:06:30 GMT
Expires:Tue, 04 Apr 2017 07:06:30 GMT
Pragma:public