### PR TITLE
[!!!][TASK] removed felogin constants (redirects), added new constant..

### DIFF
--- a/Configuration/TypoScript/Library/lib.menu.top.setupts
+++ b/Configuration/TypoScript/Library/lib.menu.top.setupts
@@ -13,7 +13,13 @@ lib.menu.top.1 {
     NO.stdWrap.wrap.required = 1
     NO.stdWrap.wrap.dataWrap = <span class="icons icon-|"></span>
     NO.stdWrap.innerWrap.noTrimWrap = |&nbsp;||
+    NO.additionalParams = &logintype=logout
+    NO.additionalParams {
+        if.isInList.field = uid
+        if.value = {$themes.configuration.header.top.menu.logoutMenuItemPageUid}
+    }
     ACT < .NO
     ACT.wrapItemAndSub.insertData = 1
     ACT.wrapItemAndSub = <li class="_active uid-{field:uid} point-{register:count_MENUOBJ} first">|</li>|*|<li class="_active uid-{field:uid} point-{register:count_MENUOBJ} middle">|</li>|*|<li class="_active uid-{field:uid} point-{register:count_MENUOBJ} last">|</li>
 }
+

--- a/Configuration/TypoScript/Library/plugin.tx_felogin_pi1.constantsts
+++ b/Configuration/TypoScript/Library/plugin.tx_felogin_pi1.constantsts
@@ -1,3 +1,0 @@
-
-plugin.tx_felogin_pi1.redirectPageLogin = 112
-plugin.tx_felogin_pi1.redirectPageLogout = 25

--- a/Configuration/TypoScript/Library/plugin.tx_felogin_pi1.setupts
+++ b/Configuration/TypoScript/Library/plugin.tx_felogin_pi1.setupts
@@ -73,7 +73,4 @@ plugin.tx_felogin_pi1 {
             wrap = <strong>|</strong>
         }
     }
-
-    redirectPageLogin = {$plugin.tx_felogin_pi1.redirectPageLogin}
-    redirectPageLogout = {$plugin.tx_felogin_pi1.redirectPageLogout}
 }

--- a/Configuration/TypoScript/Library/themes.header.constantsts
+++ b/Configuration/TypoScript/Library/themes.header.constantsts
@@ -25,7 +25,8 @@ themes.configuration.elem.status.headerTopNavigationVisibleInMobileMenu = 0
 themes.configuration.elem.status.headerTopNavigationAsOneItemInMobileMenu = 1
 # cat=header,advanced/header_top; type=int+; label= Header Top: Container pid where the menu items are located
 themes.configuration.header.top.menu.containerPid = 6
-
+# cat=header,advanced/header_top; type=int+; label= Logout menu item page id : Will add additional link parameter "&logintype=logout" to link.
+themes.configuration.header.top.menu.logoutMenuItemPageUid = 112
 
 #Header Middle
 #############################################

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -586,7 +586,7 @@ class ext_update
                     $queryBuilder->expr()->in(
                         'CType',
                         $queryBuilder->createNamedParameter(
-                            ['imageTextLink', 'responsiveVideo', 'gridelements_pi1', 'uploads'],
+                            ['imageTextLink', 'responsiveVideo'],
                             Connection::PARAM_STR_ARRAY
                         )
                     )
@@ -657,7 +657,7 @@ class ext_update
                     $queryBuilder->expr()->in(
                         'CType',
                         $queryBuilder->createNamedParameter(
-                            ['imageTextLink', 'responsiveVideo', 'gridelements_pi1'],
+                            ['imageTextLink', 'responsiveVideo'],
                             Connection::PARAM_STR_ARRAY
                         )
                     )


### PR DESCRIPTION
.. for logoutMenuItemPageUid

[!!!] Need to specify redirects for login and logout if constants where used.
Setting logoutMenuItemPageUid will add parameter "&logintype=logout" to page with this id in "meta menu".
