### PR TITLE
[FIX] force jquery to be included first

### DIFF
--- a/Configuration/TypoScript/Library/page.includeJS.setupts
+++ b/Configuration/TypoScript/Library/page.includeJS.setupts
@@ -4,6 +4,7 @@
             jquery = {$themes.configuration.feLayoutPath}/less/jquery.js
             jquery {
                 external = 0
+                forceOnTop = 1
                 # disableCompression =
                 # excludeFromConcatenation =
             }
@@ -37,6 +38,7 @@
             jquery = {$themes.configuration.feLayoutPath}/css/jquery.js
             jquery {
                 external = 0
+                forceOnTop = 1
                 # disableCompression =
                 # excludeFromConcatenation =
             }


### PR DESCRIPTION
otherwise there could be errors from 3rd party extensions which includes theirs scripst before it