### PR TITLE
[BUGFIX] long menu entries don't fit in the navigation dropdown

### DIFF
--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -548,7 +548,7 @@
   margin: 0;
   overflow: hidden;
   max-height: 0;
-  width: 100%;
+  width: auto;
   position: relative;
   opacity: 0;
   visibility: hidden;

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -1893,7 +1893,7 @@
     margin: 0;
     overflow: hidden;
     max-height: 0;
-    width: 100%;
+    width: auto;
     position: relative;
     opacity: 0;
     visibility: hidden;

--- a/felayout_t3kit/dev/styles/main/header/header.less
+++ b/felayout_t3kit/dev/styles/main/header/header.less
@@ -570,7 +570,7 @@
     margin: 0;
     overflow: hidden;
     max-height: 0;
-    width: 100%;
+    width: auto;
     position: relative;
     opacity: 0;
     visibility: hidden;


### PR DESCRIPTION
This PR set main navigation container width to auto so that  long menu entries fit in the navigation dropdown. Screenshots here: #246 