### PR TITLE
[BUGFIX] fix 'white screen' in frontend for TYPO3 8.7.2, resolves #249

### DIFF
--- a/Configuration/TypoScript/Library/config.setupts
+++ b/Configuration/TypoScript/Library/config.setupts
@@ -15,6 +15,7 @@ config {
     spamProtectEmailAddresses_lastDotSubst = {$themes.configuration.spamProtectEmailAddresses.lastDotSubst}
     headerComment = {$themes.configuration.headerComment}
     sendCacheHeaders = 1
+    metaCharset = utf-8
 }
 
 


### PR DESCRIPTION
add config.metaCharset = utf-8 setting in theme_t3kit to override uppercase setting from themes