### PR TITLE
[FEATURE] Add google site verification meta tag.

### DIFF
--- a/Configuration/TypoScript/Library/page.siteverification.setupts
+++ b/Configuration/TypoScript/Library/page.siteverification.setupts
@@ -1,0 +1,10 @@
+#Google site verification meta tag only for the startpage
+[globalVar = TSFE:id={$themes.configuration.pages.startsite}]
+  page.meta {
+    google-site-verification = TEXT
+    google-site-verification {
+        if.isPositive = {$themes.configuration.tracking.ga_siteVerification}
+        value = {$themes.configuration.tracking.ga_siteVerification}
+    }
+   }
+[end]

--- a/Configuration/TypoScript/Library/themes.analytics.constantsts
+++ b/Configuration/TypoScript/Library/themes.analytics.constantsts
@@ -1,6 +1,0 @@
-#############################################
-# Google Analytics tracking
-#############################################
-# customsubcategory=analytics= Analytics
-# cat=theme,expert/analytics/; type=string; label= Google Analytics Account
-themes.configuration.tracking.ga_account =

--- a/Configuration/TypoScript/Library/themes.googlewebmastertools.constantsts
+++ b/Configuration/TypoScript/Library/themes.googlewebmastertools.constantsts
@@ -1,0 +1,14 @@
+#############################################
+# Google Analytics tracking
+#############################################
+# customsubcategory=googleWebMasterTools= Google Webmaster Tools
+# cat=theme,expert/googleWebMasterTools/; type=string; label= Google Analytics Account
+themes.configuration.tracking.ga_account =
+
+
+#############################################
+# Google site verification code
+#############################################
+# customsubcategory=googleWebMasterTools= Google Webmaster Tools
+# cat=theme,expert/googleWebMasterTools/; type=string; label= Google Search Console
+themes.configuration.tracking.ga_siteVerification =


### PR DESCRIPTION
Add theme constant for google site verification code. The meta tag is only needed on the startpage.
Move analytics constant to Google Webmaster Tools section.