### PR TITLE
[BUGFIX]: add position absolute for preview image in news simple list

### DIFF
--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -1954,6 +1954,7 @@
 .news-simple-list__media-preview {
   width: 100%;
   height: 100%;
+  position: absolute;
 }
 .news-simple-list__text {
   overflow: hidden;

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -3626,6 +3626,7 @@
 .news-simple-list__media-preview {
     width: 100%;
     height: 100%;
+    position: absolute;
 }
 
 .news-simple-list__text {

--- a/felayout_t3kit/dev/styles/main/plugins/news/newsSimpleList.less
+++ b/felayout_t3kit/dev/styles/main/plugins/news/newsSimpleList.less
@@ -20,6 +20,7 @@
 .news-simple-list__media-preview {
     width: 100%;
     height: 100%;
+    position: absolute;
 }
 
 .news-simple-list__text {


### PR DESCRIPTION
Default preview image was not visible without position style.