### PR TITLE
 [!!!][TASK] update default groupid for new pages

### DIFF
--- a/Configuration/PageTS/tsconfig.txt
+++ b/Configuration/PageTS/tsconfig.txt
@@ -35,7 +35,7 @@ TCEFORM.tt_content.tx_themes_behaviour.disabled = 1
 
 
 TCEMAIN.permissions {
-    groupid = 3
+    groupid = 7
     user = show,editcontent,new,edit,delete
     group = show,editcontent,new,edit,delete
 }


### PR DESCRIPTION
Set default group id to 7, Editor Page Access
!!! BE group with id 7 was created after Release 2.3.0 of t3kit/t3kit_db