### PR TITLE
[!!!][BUGFIX] use NoBgImage layout for content elements based on gridelements ext. except grids, fix #255

### DIFF
--- a/Resources/Private/Layouts/GridElements/NoBgImage.html
+++ b/Resources/Private/Layouts/GridElements/NoBgImage.html
@@ -7,7 +7,7 @@
 	</f:if>
 
 	<f:comment><!-- ### element body ### --></f:comment>
-	<div id="c{data.uid}" class="frame frame-type-{data.CType} {layoutClass} {f:if(condition: data.layout, then: ' frame-layout-{data.layout}')} {alignClass} {f:if( condition: data.flexform_container, then: ' {data.flexform_container}')}">
+	<div id="c{data.uid}" class="frame frame-type-{data.CType} {layoutClass} {f:if(condition: data.layout, then: ' frame-layout-{data.layout}')} {alignClass}">
 		<f:if condition="{data._LOCALIZED_UID}">
 			<a id="c{data._LOCALIZED_UID}"></a>
 		</f:if>

--- a/Resources/Private/Templates/GridElements/Collapsible.html
+++ b/Resources/Private/Templates/GridElements/Collapsible.html
@@ -1,4 +1,4 @@
-<f:layout name="{f:if(condition: data.tx_gridelements_container, then: 'Empty', else: 'Default')}" />
+<f:layout name="{f:if(condition: data.tx_gridelements_container, then: 'Empty', else: 'NoBgImage')}" />
 <f:section name="Main">
 	<div class="panel panel-default {layoutClass} {alignClass}">
 		<div class="panel-heading" role="tab" id="heading-{data.uid}">

--- a/Resources/Private/Templates/GridElements/CollapsibleGroup.html
+++ b/Resources/Private/Templates/GridElements/CollapsibleGroup.html
@@ -1,4 +1,4 @@
-<f:layout name="Default" />
+<f:layout name="NoBgImage" />
 <f:section name="Main">
 	<div class="panel-group" id="group-{f:if(condition: data._LOCALIZED_UID, then: data._LOCALIZED_UID, else: data.uid)}" role="tablist" aria-multiselectable="{f:if(condition: '{data.pi_flexform.data.columns.lDEF.multiselectable.vDEF}', then: 'true', else: 'false')}">
 		<f:format.raw>{data.tx_gridelements_view_column_0}</f:format.raw>

--- a/Resources/Private/Templates/GridElements/SimpleAccordion.html
+++ b/Resources/Private/Templates/GridElements/SimpleAccordion.html
@@ -1,5 +1,5 @@
 {namespace theme=KayStrobach\Themes\ViewHelpers}
-<f:layout name="{f:if(condition: data.tx_gridelements_container, then: 'Empty', else: 'Default')}" />
+<f:layout name="NoBgImage" />
 <f:section name="Main">
 	<div class="panel-group" id="group-{f:if(condition: data._LOCALIZED_UID, then: data._LOCALIZED_UID, else: data.uid)}" role="tablist">
 		<f:for each="{data.tx_gridelements_view_children}" as="panel" iteration="panelnumber">

--- a/Resources/Private/Templates/GridElements/SliderContainer.html
+++ b/Resources/Private/Templates/GridElements/SliderContainer.html
@@ -1,4 +1,4 @@
-<f:layout name="Default" />
+<f:layout name="NoBgImage" />
 <f:section name="Main">
 	<f:if condition="{data.pi_flexform.data.columns.lDEF.grid_container.vDEF}">
 		<div class="container">

--- a/Resources/Private/Templates/GridElements/Tab.html
+++ b/Resources/Private/Templates/GridElements/Tab.html
@@ -1,4 +1,4 @@
-<f:layout name="{f:if(condition: data.tx_gridelements_container, then: 'Empty', else: 'Default')}" />
+<f:layout name="{f:if(condition: data.tx_gridelements_container, then: 'Empty', else: 'NoBgImage')}" />
 <f:section name="Main">
 	<f:format.raw>{data.tx_gridelements_view_column_0}</f:format.raw>
 </f:section>

--- a/Resources/Private/Templates/GridElements/TabGroup.html
+++ b/Resources/Private/Templates/GridElements/TabGroup.html
@@ -1,4 +1,4 @@
-<f:layout name="Default" />
+<f:layout name="NoBgImage" />
 <f:section name="Main">
 	<ul class="nav {f:if(condition: '{data.pi_flexform.data.columns.lDEF.tabstyle.vDEF}', then: 'nav-pills', else: 'nav-tabs')}" role="tablist" id="tab-{f:if(condition: data._LOCALIZED_UID, then: data._LOCALIZED_UID, else: data.uid)}" >
 		<f:for each="{data.tx_gridelements_view_children}" as="tab" iteration="tabIteration">


### PR DESCRIPTION
My suggestion to use `NoBgImage` for content elements based on Gridelements but not grids itself

`NoBgImage` layout doesn't have those options `lib.responsiveBackgroundImage` and `data.flexform_container` and we do not need it for this elements: SliderContainer, Collapsible, Parallax etc.

It also can cause bugs:
https://github.com/t3kit/theme_t3kit/issues/255