### PR TITLE
[TASK]: add footer html classes to gridelements column layouts

### DIFF
--- a/Configuration/GridElements/FlexForms/Adv1ColumnGrid.xml
+++ b/Configuration/GridElements/FlexForms/Adv1ColumnGrid.xml
@@ -311,6 +311,18 @@
 													<numIndex index="0">-</numIndex>
 													<numIndex index="1"></numIndex>
 												</numIndex>
+													<numIndex index="1">
+														<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_quick_links</numIndex>
+														<numIndex index="1">footer__quick-links</numIndex>
+													</numIndex>
+													<numIndex index="2">
+														<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_copyright</numIndex>
+														<numIndex index="1">footer__bottom-copyright</numIndex>
+													</numIndex>
+													<numIndex index="3">
+														<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_bottom_nav</numIndex>
+														<numIndex index="1">footer__bottom-nav</numIndex>
+													</numIndex>
 											</items>
 											<default></default>
 									</config>

--- a/Configuration/GridElements/FlexForms/Adv2ColumnGrid.xml
+++ b/Configuration/GridElements/FlexForms/Adv2ColumnGrid.xml
@@ -311,6 +311,18 @@
 													<numIndex index="0">-</numIndex>
 													<numIndex index="1"></numIndex>
 												</numIndex>
+												<numIndex index="1">
+													<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_quick_links</numIndex>
+													<numIndex index="1">footer__quick-links</numIndex>
+												</numIndex>
+												<numIndex index="2">
+													<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_copyright</numIndex>
+													<numIndex index="1">footer__bottom-copyright</numIndex>
+												</numIndex>
+												<numIndex index="3">
+													<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_bottom_nav</numIndex>
+													<numIndex index="1">footer__bottom-nav</numIndex>
+												</numIndex>
 											</items>
 											<default></default>
 									</config>
@@ -676,6 +688,18 @@
 												<numIndex index="0" type="array">
 													<numIndex index="0">-</numIndex>
 													<numIndex index="1"></numIndex>
+												</numIndex>
+												<numIndex index="1">
+													<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_quick_links</numIndex>
+													<numIndex index="1">footer__quick-links</numIndex>
+												</numIndex>
+												<numIndex index="2">
+													<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_copyright</numIndex>
+													<numIndex index="1">footer__bottom-copyright</numIndex>
+												</numIndex>
+												<numIndex index="3">
+													<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_bottom_nav</numIndex>
+													<numIndex index="1">footer__bottom-nav</numIndex>
 												</numIndex>
 											</items>
 											<default></default>

--- a/Configuration/GridElements/FlexForms/Adv3ColumnGrid.xml
+++ b/Configuration/GridElements/FlexForms/Adv3ColumnGrid.xml
@@ -311,6 +311,18 @@
 												<numIndex index="0">-</numIndex>
 												<numIndex index="1"></numIndex>
 											</numIndex>
+											<numIndex index="1">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_quick_links</numIndex>
+												<numIndex index="1">footer__quick-links</numIndex>
+											</numIndex>
+											<numIndex index="2">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_copyright</numIndex>
+												<numIndex index="1">footer__bottom-copyright</numIndex>
+											</numIndex>
+											<numIndex index="3">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_bottom_nav</numIndex>
+												<numIndex index="1">footer__bottom-nav</numIndex>
+											</numIndex>
 										</items>
 										<default></default>
 								</config>
@@ -677,6 +689,18 @@
 												<numIndex index="0">-</numIndex>
 												<numIndex index="1"></numIndex>
 											</numIndex>
+											<numIndex index="1">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_quick_links</numIndex>
+												<numIndex index="1">footer__quick-links</numIndex>
+											</numIndex>
+											<numIndex index="2">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_copyright</numIndex>
+												<numIndex index="1">footer__bottom-copyright</numIndex>
+											</numIndex>
+											<numIndex index="3">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_bottom_nav</numIndex>
+												<numIndex index="1">footer__bottom-nav</numIndex>
+											</numIndex>
 										</items>
 										<default></default>
 								</config>
@@ -1042,6 +1066,18 @@
 											<numIndex index="0" type="array">
 												<numIndex index="0">-</numIndex>
 												<numIndex index="1"></numIndex>
+											</numIndex>
+											<numIndex index="1">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_quick_links</numIndex>
+												<numIndex index="1">footer__quick-links</numIndex>
+											</numIndex>
+											<numIndex index="2">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_copyright</numIndex>
+												<numIndex index="1">footer__bottom-copyright</numIndex>
+											</numIndex>
+											<numIndex index="3">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_bottom_nav</numIndex>
+												<numIndex index="1">footer__bottom-nav</numIndex>
 											</numIndex>
 										</items>
 										<default></default>

--- a/Configuration/GridElements/FlexForms/Adv4ColumnGrid.xml
+++ b/Configuration/GridElements/FlexForms/Adv4ColumnGrid.xml
@@ -311,6 +311,18 @@
 												<numIndex index="0">-</numIndex>
 												<numIndex index="1"></numIndex>
 											</numIndex>
+											<numIndex index="1">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_quick_links</numIndex>
+												<numIndex index="1">footer__quick-links</numIndex>
+											</numIndex>
+											<numIndex index="2">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_copyright</numIndex>
+												<numIndex index="1">footer__bottom-copyright</numIndex>
+											</numIndex>
+											<numIndex index="3">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_bottom_nav</numIndex>
+												<numIndex index="1">footer__bottom-nav</numIndex>
+											</numIndex>
 										</items>
 										<default></default>
 								</config>
@@ -676,6 +688,18 @@
 											<numIndex index="0" type="array">
 												<numIndex index="0">-</numIndex>
 												<numIndex index="1"></numIndex>
+											</numIndex>
+											<numIndex index="1">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_quick_links</numIndex>
+												<numIndex index="1">footer__quick-links</numIndex>
+											</numIndex>
+											<numIndex index="2">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_copyright</numIndex>
+												<numIndex index="1">footer__bottom-copyright</numIndex>
+											</numIndex>
+											<numIndex index="3">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_bottom_nav</numIndex>
+												<numIndex index="1">footer__bottom-nav</numIndex>
 											</numIndex>
 										</items>
 										<default></default>
@@ -1043,6 +1067,18 @@
 												<numIndex index="0">-</numIndex>
 												<numIndex index="1"></numIndex>
 											</numIndex>
+											<numIndex index="1">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_quick_links</numIndex>
+												<numIndex index="1">footer__quick-links</numIndex>
+											</numIndex>
+											<numIndex index="2">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_copyright</numIndex>
+												<numIndex index="1">footer__bottom-copyright</numIndex>
+											</numIndex>
+											<numIndex index="3">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_bottom_nav</numIndex>
+												<numIndex index="1">footer__bottom-nav</numIndex>
+											</numIndex>
 										</items>
 										<default></default>
 								</config>
@@ -1408,6 +1444,18 @@
 											<numIndex index="0" type="array">
 												<numIndex index="0">-</numIndex>
 												<numIndex index="1"></numIndex>
+											</numIndex>
+											<numIndex index="1">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_quick_links</numIndex>
+												<numIndex index="1">footer__quick-links</numIndex>
+											</numIndex>
+											<numIndex index="2">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_copyright</numIndex>
+												<numIndex index="1">footer__bottom-copyright</numIndex>
+											</numIndex>
+											<numIndex index="3">
+												<numIndex index="0">LLL:EXT:theme_t3kit/Resources/Private/Language/GridElements.xlf:column_layout.footer_bottom_nav</numIndex>
+												<numIndex index="1">footer__bottom-nav</numIndex>
 											</numIndex>
 										</items>
 										<default></default>

--- a/Resources/Private/Language/GridElements.xlf
+++ b/Resources/Private/Language/GridElements.xlf
@@ -122,6 +122,16 @@
 			<trans-unit id="column_4_layout">
 				<source>Column 4 Layout</source>
 			</trans-unit>
+			<trans-unit id="column_layout.footer_quick_links">
+				<source>Footer quick links</source>
+			</trans-unit>
+			<trans-unit id="column_layout.footer_copyright">
+				<source>Footer copyright</source>
+			</trans-unit>
+			<trans-unit id="column_layout.footer_bottom_nav">
+				<source>Footer bottom navigation</source>
+			</trans-unit>
+
 
 			<trans-unit id="column_1_offset">
 				<source>Column 1 Offset</source>


### PR DESCRIPTION
Currently the backend editor has to add this classes in the Grid Column Class input. To prevent mistakes and troubles it would be easier to add this classes predefined in the Grid Column Layout dropdown.