### PR TITLE
[BUGFIX] add no icon config to divider

### DIFF
--- a/Configuration/FlexForms/flexform_div.xml
+++ b/Configuration/FlexForms/flexform_div.xml
@@ -18,6 +18,7 @@
 								<userFunc>T3kit\themeT3kit\UserFunction\IconFontSelector->renderField</userFunc>
 								<cssFile>EXT:theme_t3kit/Resources/Public/IconFonts/style.css</cssFile>
 								<isIcoMoon>1</isIcoMoon>
+								<default>0</default>
 							</config>
 						</TCEforms>
 					</iconClass>


### PR DESCRIPTION
BUG -> couldn't add default divider with no icon