### PR TITLE
Add additional checkboxes for ResponsiveVideo element

### DIFF
--- a/Configuration/FlexForms/flexform_responsiveVideo.xml
+++ b/Configuration/FlexForms/flexform_responsiveVideo.xml
@@ -1,0 +1,25 @@
+<T3DataStructure>
+	<meta>
+		<langDisable>1</langDisable>
+	</meta>
+	<sheets>
+		<sDEF>
+			<ROOT>
+				<TCEforms>
+					<sheetTitle>LLL:EXT:theme_t3kit/Resources/Private/Language/ContentElements.xlf:elem.flexform.sheetGeneral</sheetTitle>
+				</TCEforms>
+				<type>array</type>
+				<el>
+					<includeRelatedVideos>
+						<TCEforms>
+							<label>LLL:EXT:theme_t3kit/Resources/Private/Language/ContentElements.xlf:responsiveVideo.flexform.includeRelatedVideos</label>
+							<config>
+								<type>check</type>
+							</config>
+						</TCEforms>
+					</includeRelatedVideos>
+				</el>
+			</ROOT>
+		</sDEF>
+	</sheets>
+</T3DataStructure>

--- a/Configuration/FlexForms/flexform_responsiveVideo.xml
+++ b/Configuration/FlexForms/flexform_responsiveVideo.xml
@@ -10,14 +10,30 @@
 				</TCEforms>
 				<type>array</type>
 				<el>
-					<includeRelatedVideos>
+					<enableShowInfo>
 						<TCEforms>
-							<label>LLL:EXT:theme_t3kit/Resources/Private/Language/ContentElements.xlf:responsiveVideo.flexform.includeRelatedVideos</label>
+							<label>LLL:EXT:theme_t3kit/Resources/Private/Language/ContentElements.xlf:responsiveVideo.flexform.enableShowInfo</label>
 							<config>
 								<type>check</type>
 							</config>
 						</TCEforms>
-					</includeRelatedVideos>
+					</enableShowInfo>
+					<enableRelatedVideos>
+						<TCEforms>
+							<label>LLL:EXT:theme_t3kit/Resources/Private/Language/ContentElements.xlf:responsiveVideo.flexform.enableRelatedVideos</label>
+							<config>
+								<type>check</type>
+							</config>
+						</TCEforms>
+					</enableRelatedVideos>
+					<enableLoop>
+						<TCEforms>
+							<label>LLL:EXT:theme_t3kit/Resources/Private/Language/ContentElements.xlf:responsiveVideo.flexform.enableLoop</label>
+							<config>
+								<type>check</type>
+							</config>
+						</TCEforms>
+					</enableLoop>
 				</el>
 			</ROOT>
 		</sDEF>

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -534,8 +534,7 @@ call_user_func(function() {
                 header;' . $frontendLanguageFilePrefix . 'header.ALT.div_formlabel,
 
             --div--;' . $contentElementLanguageFilePrefix . 'responsiveVideo.tabs.video,assets,
-
-            --div--;' . $contentElementLanguageFilePrefix . 'responsiveVideo.tabs.video,assets,
+            --linebreak--,pi_flexform;' . $contentElementLanguageFilePrefix . 'tt_content.tabs.settings,
 
             --div--;' . $frontendLanguageFilePrefix . 'tabs.appearance,
                 --palette--;' . $frontendLanguageFilePrefix . 'palette.frames;frames,

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -535,6 +535,8 @@ call_user_func(function() {
 
             --div--;' . $contentElementLanguageFilePrefix . 'responsiveVideo.tabs.video,assets,
 
+            --div--;' . $contentElementLanguageFilePrefix . 'responsiveVideo.tabs.video,assets,
+
             --div--;' . $frontendLanguageFilePrefix . 'tabs.appearance,
                 --palette--;' . $frontendLanguageFilePrefix . 'palette.frames;frames,
                 --palette--;' . $frontendLanguageFilePrefix . 'palette.appearanceLinks;appearanceLinks,
@@ -550,6 +552,7 @@ call_user_func(function() {
     ];
 
     // responsiveVideo flexform
+    $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds']['*,responsiveVideo'] = $flexformPath . 'flexform_responsiveVideo.xml';
     // ======================= responsiveVideo [end] ==========================================
 
 

--- a/Resources/Private/Language/ContentElements.xlf
+++ b/Resources/Private/Language/ContentElements.xlf
@@ -347,8 +347,14 @@
 			<trans-unit id="responsiveVideo.tabs.video">
 				<source>Video</source>
 			</trans-unit>
-			<trans-unit id="responsiveVideo.flexform.includeRelatedVideos">
-				<source>Include related videos</source>
+			<trans-unit id="responsiveVideo.flexform.enableShowInfo">
+				<source>Youtube and Vimeo: Show video title and uploader before video starts playing</source>
+			</trans-unit>
+			<trans-unit id="responsiveVideo.flexform.enableRelatedVideos">
+				<source>YouTube: Enable related videos</source>
+			</trans-unit>
+			<trans-unit id="responsiveVideo.flexform.enableLoop">
+				<source>Enable looping - video starts over again from the beginnning when finished</source>
 			</trans-unit>
 
 

--- a/Resources/Private/Language/ContentElements.xlf
+++ b/Resources/Private/Language/ContentElements.xlf
@@ -347,7 +347,7 @@
 			<trans-unit id="responsiveVideo.tabs.video">
 				<source>Video</source>
 			</trans-unit>
-			<trans-unit id="fullWidthImage.flexform.includeRelatedVideos">
+			<trans-unit id="responsiveVideo.flexform.includeRelatedVideos">
 				<source>Include related videos</source>
 			</trans-unit>
 

--- a/Resources/Private/Language/ContentElements.xlf
+++ b/Resources/Private/Language/ContentElements.xlf
@@ -347,6 +347,10 @@
 			<trans-unit id="responsiveVideo.tabs.video">
 				<source>Video</source>
 			</trans-unit>
+			<trans-unit id="fullWidthImage.flexform.includeRelatedVideos">
+				<source>Include related videos</source>
+			</trans-unit>
+
 
 			<!--SocialIcons Element-->
 			<trans-unit id="socialIcons.title">
@@ -406,25 +410,25 @@
 			<trans-unit id="contactsCard.description">
 				<source>Photo and contact information</source>
 			</trans-unit>
-			<trans-unit id="contactsCard.name"> 
+			<trans-unit id="contactsCard.name">
 				<source>Full Name</source>
 			</trans-unit>
-			<trans-unit id="contactsCard.job"> 
+			<trans-unit id="contactsCard.job">
 				<source>Job Description</source>
 			</trans-unit>
-			<trans-unit id="contactsCard.flexform.contactPhone_1"> 
+			<trans-unit id="contactsCard.flexform.contactPhone_1">
 				<source>Contact Phone 1</source>
 			</trans-unit>
-			<trans-unit id="contactsCard.flexform.contactPhone_2"> 
+			<trans-unit id="contactsCard.flexform.contactPhone_2">
 				<source>Contact Phone 2</source>
 			</trans-unit>
-			<trans-unit id="contactsCard.flexform.mobilePhone"> 
+			<trans-unit id="contactsCard.flexform.mobilePhone">
 				<source>Mobile Phone</source>
 			</trans-unit>
-			<trans-unit id="contactsCard.flexform.email"> 
+			<trans-unit id="contactsCard.flexform.email">
 				<source>E-mail</source>
 			</trans-unit>
-			<trans-unit id="contactsCard.flexform.linkedInLink"> 
+			<trans-unit id="contactsCard.flexform.linkedInLink">
 				<source>Link to LinkedIn Profile</source>
 			</trans-unit>
 

--- a/Resources/Private/Templates/ContentElements/ResponsiveVideo.html
+++ b/Resources/Private/Templates/ContentElements/ResponsiveVideo.html
@@ -8,17 +8,17 @@
 		<f:for each="{assets}" as="video" iteration="videoIteration">
 			<f:if condition="{video.type} == 4">
 				<div class="embed-responsive embed-responsive-16by9">
-					<f:if condition="{settings.includeRelatedVideos}">
+					<f:if condition="{settings.includeRelatedVideos}=='0' || {settings.includeRelatedVideos}=='1'">
 						<f:then>
 							<f:media
 								class="embed-responsive-item"
 								file="{video}"
 								alt="{video.alternative}"
 								title="{video.title}"
-								additionalConfig="{relatedVideos: '0'}"
-							/>hej
+								additionalConfig="{relatedVideos: settings.includeRelatedVideos}"
+							/>
 						</f:then>
-						<f:else>då
+						<f:else>
 							<f:media
 								class="embed-responsive-item"
 								file="{video}"

--- a/Resources/Private/Templates/ContentElements/ResponsiveVideo.html
+++ b/Resources/Private/Templates/ContentElements/ResponsiveVideo.html
@@ -8,14 +8,14 @@
 		<f:for each="{assets}" as="video" iteration="videoIteration">
 			<f:if condition="{video.type} == 4">
 				<div class="embed-responsive embed-responsive-16by9">
-					<f:if condition="{settings.includeRelatedVideos}=='0' || {settings.includeRelatedVideos}=='1'">
+					<f:if condition="{settings.enableShowInfo}=='0' || {settings.enableShowInfo}=='1'">
 						<f:then>
 							<f:media
 								class="embed-responsive-item"
 								file="{video}"
 								alt="{video.alternative}"
 								title="{video.title}"
-								additionalConfig="{relatedVideos: settings.includeRelatedVideos}"
+								additionalConfig="{showinfo: settings.enableShowInfo, relatedVideos: settings.enableRelatedVideos, loop: settings.enableLoop}"
 							/>
 						</f:then>
 						<f:else>

--- a/Resources/Private/Templates/ContentElements/ResponsiveVideo.html
+++ b/Resources/Private/Templates/ContentElements/ResponsiveVideo.html
@@ -8,12 +8,25 @@
 		<f:for each="{assets}" as="video" iteration="videoIteration">
 			<f:if condition="{video.type} == 4">
 				<div class="embed-responsive embed-responsive-16by9">
-					<f:media
-						class="embed-responsive-item"
-						file="{video}"
-						alt="{video.alternative}"
-						title="{video.title}"
-					/>
+					<f:if condition="{settings.includeRelatedVideos}">
+						<f:then>
+							<f:media
+								class="embed-responsive-item"
+								file="{video}"
+								alt="{video.alternative}"
+								title="{video.title}"
+								additionalConfig="{relatedVideos: '0'}"
+							/>hej
+						</f:then>
+						<f:else>då
+							<f:media
+								class="embed-responsive-item"
+								file="{video}"
+								alt="{video.alternative}"
+								title="{video.title}"
+							/>
+						</f:else>
+					</f:if>
 				</div>
 			</f:if>
 		</f:for>


### PR DESCRIPTION
This pull-request adds the following checkboxes to the Responsive Video-element:
Youtube and Vimeo: Show video title and uploader before video starts playing
YouTube: Enable related videos
Enable looping - video starts over again from the beginnning when finished

The initial reason for this work was to enable the editor to disable YouTube's related videos, as they are on by default and several clients requested to be able to turn this off.

A condition is added in the template to ensure older instances of this element (without these values set) should not be affected until saved again. So there should not be any breaking changes.

Two references in TYPO3.CMS:
https://github.com/TYPO3/TYPO3.CMS/blob/master/typo3/sysext/core/Classes/Resource/Rendering/YouTubeRenderer.php
https://github.com/TYPO3/TYPO3.CMS/blob/master/typo3/sysext/core/Classes/Resource/Rendering/VimeoRenderer.php