### PR TITLE
[TASK] adjust mobile image display in bootstrap carousel

### DIFF
--- a/felayout_t3kit/dev/styles/main/contentElements/bootstrapCarousel.less
+++ b/felayout_t3kit/dev/styles/main/contentElements/bootstrapCarousel.less
@@ -47,15 +47,14 @@
     }
 
     // Show only center of image, it is only 300px height
-    > .item > img,
-    > .item > a > img {
+    > .item img,
+    > .item > a img {
         height: 100%;
         max-width: none;
         left: 50%;
-        top: 50%;
         position: relative;
         width: auto;
-        .translate(-50%, -50%);
+        .translate(-50%, 0);
     }
 
     > .active,
@@ -217,11 +216,10 @@
         }
 
         // Make images fit in the item size, remove centered image area
-        > .item > img,
-        > .item > a > img {
+        > .item img,
+        > .item > a img {
             width: 100%;
             height: auto;
-            top: 0;
             left: 0;
             transform: none;
         }


### PR DESCRIPTION
If a picture-tag is between img and .item, the css should work also