### PR TITLE
[FEATURE] add aria tags to icon text and link element

### DIFF
--- a/Resources/Private/Templates/ContentElements/BigIconTextButton.html
+++ b/Resources/Private/Templates/ContentElements/BigIconTextButton.html
@@ -7,7 +7,7 @@
 	<div class="big-icon-text-btn__wrp">
 		<div class="big-icon-text-btn{f:if(condition: settings.disableWholeAreaLink, then: '', else: ' _whole-area-link')}">
 			<f:if condition="{settings.iconClass}">
-				<span class="big-icon-text-btn__icon icons icon-{settings.iconClass}"></span>
+				<span class="big-icon-text-btn__icon icons icon-{settings.iconClass}" aria-hidden="true"></span>
 			</f:if>
 			<f:if condition="{data.header}">
 				<h3 class="big-icon-text-btn__header"><core:contentEditable table="tt_content" field="header" uid="{data.uid}">{data.header}</core:contentEditable></h3>
@@ -27,7 +27,7 @@
 			</f:if>
 			<f:if condition="{settings.disableWholeAreaLink} == 0">
 				<f:if condition="{data.subheader}">
-					<span class="big-icon-text-btn__sham-link {f:if(condition: settings.btnAsLink, then: '', else: 'btn btn-default')}">{data.subheader}</span>
+					<span class="big-icon-text-btn__sham-link {f:if(condition: settings.btnAsLink, then: '', else: 'btn btn-default')}" aria-hidden="true">{data.subheader}</span>
 				</f:if>
 	 		</f:if>
 		</div>

--- a/Resources/Private/Templates/ContentElements/IconTextButton.html
+++ b/Resources/Private/Templates/ContentElements/IconTextButton.html
@@ -8,7 +8,7 @@
 		<div class="icon-text-btn{f:if(condition: settings.disableWholeAreaLink, then: '', else: ' _whole-area-link')}">
 			<h3 class="icon-text-btn__header">
 				<f:if condition="{settings.iconClass}">
-					<span class="icon-text-btn__icon icons icon-{settings.iconClass}"></span>
+					<span class="icon-text-btn__icon icons icon-{settings.iconClass}" aria-hidden="true"></span>
 				</f:if>
 				<f:if condition="{data.header}">
 					<core:contentEditable table="tt_content" field="header" uid="{data.uid}">{data.header}</core:contentEditable>
@@ -29,7 +29,7 @@
 			</f:if>
 			<f:if condition="{settings.disableWholeAreaLink} == 0">
 				<f:if condition="{data.subheader}">
-					<span class="icon-text-btn__sham-link {f:if(condition: settings.btnAsLink, then: '', else: 'btn btn-default')}">{data.subheader}</span>
+					<span class="icon-text-btn__sham-link {f:if(condition: settings.btnAsLink, then: '', else: 'btn btn-default')}" aria-hidden="true">{data.subheader}</span>
 				</f:if>
 	 		</f:if>
 		</div>


### PR DESCRIPTION
Hides the icon and the call to action button from screenreaders.
Reason:
* Iconfont can not be read by screenreaders
* Content of call to action is already given as a (visually hidden) link-tag