### PR TITLE
Adds aria role and label to svg files

### DIFF
--- a/Classes/ViewHelpers/Render/SvgViewHelper.php
+++ b/Classes/ViewHelpers/Render/SvgViewHelper.php
@@ -49,6 +49,7 @@ class SvgViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
         $this->registerArgument('class', 'string', 'Specifies an alternate class for the svg', false);
         $this->registerArgument('width', 'float', 'Specifies a width for the svg', false);
         $this->registerArgument('height', 'float', 'Specifies a height for the svg', false);
+        $this->registerArgument('aria-label', 'string', 'Specifies an aria-label for the svg', false);
     }
 
     /**
@@ -96,6 +97,10 @@ class SvgViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 
         // remove xml version tag
         $domXml = dom_import_simplexml($svgElement);
+        $domXml->setAttribute('role', 'img');
+        if (isset($this->arguments['aria-label'])) {
+            $domXml->setAttribute('aria-label', $this->arguments['aria-label']);
+        }
         if (isset($this->arguments['class'])) {
             $domXml->setAttribute('class', $this->arguments['class']);
         }

--- a/Resources/Private/Templates/FluidStyledContent/Uploads.html
+++ b/Resources/Private/Templates/FluidStyledContent/Uploads.html
@@ -7,7 +7,8 @@
 			<f:for each="{files}" as="file" iteration="fileIterator">
 				<li>
 					<f:if condition="{data.uploads_type} == 1">
-						<t3kit:render.svg source="{f:uri.resource(path: 'Icons/FileIcons/{file.extension}.svg', extensionName: 'theme_t3kit')}"></t3kit:render.svg>
+						<t3kit:render.svg aria-label="{f:translate(key:'LLL:EXT:lang/Resources/Private/Language/locallang_tca.xlf:sys_file.type')}: {file.extension}"
+										  source="{f:uri.resource(path: 'Icons/FileIcons/{file.extension}.svg', extensionName: 'theme_t3kit')}"/>
 					</f:if>
 					<f:if condition="{data.uploads_type} == 2">
 						<f:if condition="{f:uri.image(src: 'file:{f:if(condition: file.originalFile, then: \'file:{file.originalFile.uid}\', else: \'file:{file.uid}\')}')} != '/'">
@@ -17,7 +18,8 @@
 								</a>
 							</f:then>
 							<f:else>
-								<t3kit:render.svg source="{f:uri.resource(path: 'Icons/FileIcons/{file.extension}.svg', extensionName: 'theme_t3kit')}"></t3kit:render.svg>
+								<t3kit:render.svg aria-label="{f:translate(key:'LLL:EXT:lang/Resources/Private/Language/locallang_tca.xlf:sys_file.type')}: {file.extension}"
+												  source="{f:uri.resource(path: 'Icons/FileIcons/{file.extension}.svg', extensionName: 'theme_t3kit')}"/>
 							</f:else>
 						</f:if>
 					</f:if>


### PR DESCRIPTION
The SvgViewHelper is extended:

* added ``aria-label`` attribute to the svg viewhelper
* added ``role="img"`` to the svg element viewhelper

The filelist-element is extended:

* filled it with the filetype of the file to be downloaded.
"Filetype: {file extension}".
Example: "Filetype: png"