### PR TITLE
[Feature] Add aria-hidden attribute to image-text-link element

### DIFF
--- a/Resources/Private/Templates/ContentElements/ImageTextLink.html
+++ b/Resources/Private/Templates/ContentElements/ImageTextLink.html
@@ -52,7 +52,7 @@
 			<f:if condition="{settings.disableWholeAreaLink} == 0">
 				<f:if condition="{settings.hoverEffect} == 0">
 					<f:if condition="{data.subheader}">
-						<span class="img-text-link__sham-link {f:if(condition: settings.linkAsBtn, then: 'btn btn-default', else: '')}">{data.subheader}</span>
+						<span class="img-text-link__sham-link {f:if(condition: settings.linkAsBtn, then: 'btn btn-default', else: '')}" aria-hidden="true">{data.subheader}</span>
 					</f:if>
 				</f:if>
 	 		</f:if>


### PR DESCRIPTION
Screenreaders will see the link because it is only visually hidden.
They don't need to see the button because it got the text the link already offers.