### PR TITLE
[TASK]: add h2 heading to provide valid html structure

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -25,7 +25,9 @@
 			<trans-unit id="metaNavigation.ariaLabel" xml:space="preserve">
 				<source>Meta navigation</source>
 			</trans-unit>
-
+			<trans-unit id="footer.firstHeadline">
+				<source>Footer</source>
+			</trans-unit>
 
 			<!--Extensions-->
 			<!--News-->

--- a/Resources/Private/Partials/Footer/Footer.html
+++ b/Resources/Private/Partials/Footer/Footer.html
@@ -6,8 +6,10 @@
 <!-- theme_t3kit: Partials/Footer/Footer.html [begin] -->
 
 
-<footer class="footer">
-
+<footer class="footer" role="contentinfo">
+	
+	<f:comment>H2 is needed to provide valid HTML structure https://www.w3.org/WAI/tutorials/page-structure/headings/</f:comment>
+	<h2 class="hidden" aria-hidden="true"><f:translate key="footer.firstHeadline" extensionName="theme_t3kit"/></h2>
 	<f:cObject typoscriptObjectPath="lib.footer" />
 
 </footer>


### PR DESCRIPTION
Headlines in footer starts normally from h3 or h4, the page heading structure breaks without leading h2. Add role for footer to mark area for all screen readers.