### PR TITLE
Improve Breadcrumb accessibility

### DIFF
--- a/Classes/UserFunction/BreadCrumb.php
+++ b/Classes/UserFunction/BreadCrumb.php
@@ -1,0 +1,47 @@
+<?php
+namespace T3kit\themeT3kit\UserFunction;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Class to manipulate the BreadCrumb
+ *
+ * @package TYPO3
+ * @subpackage
+ * @author Markus Goldbach <markus.goldbach@dkd.de>
+ */
+class BreadCrumb
+{
+    /**
+     * Add an item to the last position of an Menu
+     *
+     * @param $menuArr
+     * @param $conf
+     * @return array
+     */
+    public function addAdditionalItem($menuArr, $conf): array
+    {
+        if (isset($GLOBALS['TSFE']->register['additionalBreadCrumbItem'])) {
+            end($menuArr);
+            $lastMenuKey = key($menuArr);
+
+            $breadcrumpItem = $menuArr[$lastMenuKey];
+            $breadcrumpItem['title'] = $GLOBALS['TSFE']->register['additionalBreadCrumbItem'];
+            $breadcrumpItem['ITEM_STATE'] = 'CUR';
+            $menuArr[$lastMenuKey]['ITEM_STATE'] = 'NO';
+            $menuArr[] = $breadcrumpItem;
+        }
+        return $menuArr;
+    }
+}

--- a/Classes/ViewHelpers/RegisterViewHelper.php
+++ b/Classes/ViewHelpers/RegisterViewHelper.php
@@ -1,0 +1,59 @@
+<?php
+namespace T3kit\themeT3kit\ViewHelpers;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * Viewhelper to store values in the TSFE register
+ *
+ * @package TYPO3
+ * @subpackage
+ * @author Markus Goldbach <markus.goldbach@dkd.de>
+ */
+class RegisterViewHelper extends AbstractViewHelper implements CompilableInterface
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * Initialize all arguments
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('key', 'string', 'the rigster where the value will be stored');
+        $this->registerArgument('value', 'string', 'the value which will be stored');
+    }
+
+    /**
+     * start to render the viewhelper
+     *
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param \TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $GLOBALS['TSFE']->register[$arguments['key']] = $arguments['value'];
+    }
+
+}

--- a/Configuration/TypoScript/Library/lib.menu.breadcrumb.setupts
+++ b/Configuration/TypoScript/Library/lib.menu.breadcrumb.setupts
@@ -1,55 +1,63 @@
 lib.menu.breadcrumb = COA
 lib.menu.breadcrumb {
-    wrap = <div class="breadcrumbs"><div class="breadcrumbs__wrp container"><ol class="breadcrumbs__list">|</ol></div></div>
-    # Render the rootline breadcrumb
-    10 = HMENU
-    10 {
-        special = rootline
-        special.range = 0|-1
-        includeNotInMenu = {$themes.configuration.menu.breadcrumb.includeNotInMenu}
-        excludeUidList = {$themes.configuration.menu.breadcrumb.excludeUidList},current
-        1 = TMENU
-        1 {
-            noBlur = 1
-            NO {
-                stdWrap.htmlSpecialChars = 1
-                doNotLinkIt = 0
-                linkWrap = <li class="breadcrumbs__list-item"><span class="icons icon-t3-home"></span>|</li> |*| <li class="breadcrumbs__list-item">|</li> |*|
-                ATagParams = class="breadcrumbs__list-link" title="{field:subtitle//field:title}"
-                ATagParams.insertData = 1
-                stdWrap.wrap = <span>|</span>
+    stdWrap.dataWrap = <nav aria-label="{LLL:EXT:theme_t3kit/Resources/Private/Language/locallang.xlf:breadcrumb.ariaLabel}"> | </nav>
+
+    10 = TEXT
+    10.data = LLL:EXT:theme_t3kit/Resources/Private/Language/locallang.xlf:breadcrumb_label
+    10.wrap = <span class="sr-only"> | </span>
+
+    20 = COA
+    20 {
+        wrap = <div class="breadcrumbs"><div class="breadcrumbs__wrp container"><ol class="breadcrumbs__list">|</ol></div></div>
+        # Render the rootline breadcrumb
+        10 = HMENU
+        10 {
+            special = rootline
+            special.range = 0|-1
+            includeNotInMenu = {$themes.configuration.menu.breadcrumb.includeNotInMenu}
+            excludeUidList = {$themes.configuration.menu.breadcrumb.excludeUidList},current
+            1 = TMENU
+            1 {
+                NO {
+                    stdWrap.htmlSpecialChars = 1
+                    doNotLinkIt = 0
+                    linkWrap = <li class="breadcrumbs__list-item"><span class="icons icon-t3-home"></span>|</li> |*| <li class="breadcrumbs__list-item">|</li> |*|
+                    ATagParams = class="breadcrumbs__list-link"
+                    ATagTitle.field = abstract // description // subtitle // title
+                    stdWrap.wrap = <span class="breadcrumbs__list-item-label">|</span>
+                }
+            }
+        }
+
+        # Render the current page and add an additional item like news category or tag
+        20 = HMENU
+        20 {
+            special = list
+            special.value.data = TSFE:id
+            includeNotInMenu = 1
+            1 = TMENU
+            1 {
+                itemArrayProcFunc = T3kit\themeT3kit\UserFunction\BreadCrumb->addAdditionalItem
+                NO < lib.menu.breadcrumb.10.1.NO
+                NO = 1
+                NO {
+                    doNotLinkIt = 0
+                    linkWrap = <li class="breadcrumbs__list-item">|</li>
+                    stdWrap.override {
+                        data = TSFE:altPageTitle
+                        stripHtml = 1
+                        if {
+                            isTrue.data = TSFE:altPageTitle
+                        }
+                    }
+                }
+                CUR < .NO
+                CUR {
+                    doNotLinkIt = 1
+                    linkWrap = <li class="breadcrumbs__list-item _active">|</li>
+                }
             }
         }
     }
 
-    # Render the current page and add an additional item like news category or tag
-    20 = HMENU
-    20 {
-        special = list
-        special.value.data = TSFE:id
-        includeNotInMenu = 1
-        1 = TMENU
-        1 {
-            itemArrayProcFunc = T3kit\themeT3kit\UserFunction\BreadCrumb->addAdditionalItem
-            noBlur = 1
-            NO < lib.menu.breadcrumb.10.1.NO
-            NO = 1
-            NO {
-                doNotLinkIt = 0
-                linkWrap = <li class="breadcrumbs__list-item">|</li>
-                stdWrap.override {
-                    data = TSFE:altPageTitle
-                    stripHtml = 1
-                    if {
-                        isTrue.data = TSFE:altPageTitle
-                    }
-                }
-            }
-            CUR < .NO
-            CUR {
-                doNotLinkIt = 1
-                linkWrap = <li class="breadcrumbs__list-item _active">|</li>
-            }
-        }
-    }
 }

--- a/Configuration/TypoScript/Library/lib.menu.breadcrumb.setupts
+++ b/Configuration/TypoScript/Library/lib.menu.breadcrumb.setupts
@@ -1,150 +1,55 @@
 lib.menu.breadcrumb = COA
 lib.menu.breadcrumb {
+    wrap = <div class="breadcrumbs"><div class="breadcrumbs__wrp container"><ol class="breadcrumbs__list">|</ol></div></div>
+    # Render the rootline breadcrumb
     10 = HMENU
     10 {
         special = rootline
         special.range = 0|-1
         includeNotInMenu = {$themes.configuration.menu.breadcrumb.includeNotInMenu}
-        excludeUidList = {$themes.configuration.menu.breadcrumb.excludeUidList}
+        excludeUidList = {$themes.configuration.menu.breadcrumb.excludeUidList},current
         1 = TMENU
         1 {
             noBlur = 1
             NO {
                 stdWrap.htmlSpecialChars = 1
-                doNotLinkIt = |*| 0 |*| 1
-                linkWrap = <li class="breadcrumbs__list-item"><span class="icons icon-t3-home"></span>|</li> |*| <li class="breadcrumbs__list-item">|</li> |*| <li class="breadcrumbs__list-item _active">|</li>
+                doNotLinkIt = 0
+                linkWrap = <li class="breadcrumbs__list-item"><span class="icons icon-t3-home"></span>|</li> |*| <li class="breadcrumbs__list-item">|</li> |*|
                 ATagParams = class="breadcrumbs__list-link" title="{field:subtitle//field:title}"
                 ATagParams.insertData = 1
                 stdWrap.wrap = <span>|</span>
             }
-            wrap = <div class="breadcrumbs"><div class="breadcrumbs__wrp container"><ol class="breadcrumbs__list">|</ol></div></div>
+        }
+    }
+
+    # Render the current page and add an additional item like news category or tag
+    20 = HMENU
+    20 {
+        special = list
+        special.value.data = TSFE:id
+        includeNotInMenu = 1
+        1 = TMENU
+        1 {
+            itemArrayProcFunc = T3kit\themeT3kit\UserFunction\BreadCrumb->addAdditionalItem
+            noBlur = 1
+            NO < lib.menu.breadcrumb.10.1.NO
+            NO = 1
+            NO {
+                doNotLinkIt = 0
+                linkWrap = <li class="breadcrumbs__list-item">|</li>
+                stdWrap.override {
+                    data = TSFE:altPageTitle
+                    stripHtml = 1
+                    if {
+                        isTrue.data = TSFE:altPageTitle
+                    }
+                }
+            }
+            CUR < .NO
+            CUR {
+                doNotLinkIt = 1
+                linkWrap = <li class="breadcrumbs__list-item _active">|</li>
+            }
         }
     }
 }
-[globalVar = GP:tx_news_pi1|news > 0] || [globalVar = GP:tx_news_pi1|overwriteDemand|categories > 0] || [globalVar = GP:tx_news_pi1|overwriteDemand|tags > 0]
-    lib.menu.breadcrumb {
-        10 {
-            1 {
-                NO {
-                    doNotLinkIt = 0
-                    linkWrap = <li class="breadcrumbs__list-item"><span class="icons icon-t3-home"></span>|</li> |*| <li class="breadcrumbs__list-item">|</li>
-                }
-                # append with news title
-                stdWrap {
-                    append = COA
-                    append {
-                        20 = RECORDS
-                        20 {
-                            dontCheckPid = 1
-                            source.intval = 1
-                            stdWrap {
-                                wrap = <li class="breadcrumbs__list-item _active">|</li>
-                                required = 1
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-[globalVar = GP:tx_news_pi1|news > 0]
-    lib.menu.breadcrumb {
-        10 {
-            1 {
-                stdWrap {
-                    append {
-                        20 {
-                            stdWrap.if.isTrue.data = GP:tx_news_pi1|news
-                            tables = tx_news_domain_model_news
-                            source.data = GP:tx_news_pi1|news
-                            conf {
-                                tx_news_domain_model_news = TEXT
-                                tx_news_domain_model_news {
-                                    field = title
-                                    htmlSpecialChars = 1
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-[globalVar = GP:tx_news_pi1|overwriteDemand|categories > 0]
-    lib.menu.breadcrumb {
-        10 {
-            1 {
-                stdWrap {
-                    append {
-                        20 {
-                            stdWrap.if.isTrue.data = GP:tx_news_pi1|overwriteDemand|categories
-                            tables = sys_category
-                            source.data = GP:tx_news_pi1|overwriteDemand|categories
-                            conf {
-                                sys_category = TEXT
-                                sys_category {
-                                    field = title
-                                    htmlSpecialChars = 1
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-[globalVar = GP:tx_news_pi1|overwriteDemand|tags > 0]
-    lib.menu.breadcrumb {
-        10 {
-            1 {
-                stdWrap {
-                    append {
-                        20 {
-                            stdWrap.if.isTrue.data = GP:tx_news_pi1|overwriteDemand|tags
-                            tables = tx_news_domain_model_tag
-                            source.data = GP:tx_news_pi1|overwriteDemand|tags
-                            conf {
-                                tx_news_domain_model_tag = TEXT
-                                tx_news_domain_model_tag {
-                                    field = title
-                                    htmlSpecialChars = 1
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-[globalVar = GP:tx_news_pi1|overwriteDemand|year > 0] && [globalVar = GP:tx_news_pi1|overwriteDemand|month > 0]
-    lib.menu.breadcrumb {
-        10 {
-            1 {
-                NO {
-                    doNotLinkIt = 0
-                    linkWrap = <li class="breadcrumbs__list-item"><span class="icons icon-t3-home"></span>|</li> |*| <li class="breadcrumbs__list-item">|</li>
-                }
-                # append with news title
-                stdWrap {
-                    append = COA
-                    append {
-                        20 = TEXT
-                        20 {
-                            dataWrap {
-                                data = GP:tx_news_pi1|overwriteDemand|month
-                                wrap = {LLL:EXT:news/Resources/Private/Language/locallang.xlf:month.|}
-                            }
-                        }
-                        30 = TEXT
-                        30 {
-                            data = GP:tx_news_pi1|overwriteDemand|year
-                            noTrimWrap = | ||
-                        }
-
-                        wrap = <li class="breadcrumbs__list-item _active">|</li>
-                    }
-                }
-            }
-        }
-    }
-[global]

--- a/Resources/Private/Extensions/News/Templates/Category/List.html
+++ b/Resources/Private/Extensions/News/Templates/Category/List.html
@@ -1,5 +1,6 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 	  xmlns:n="http://typo3.org/ns/GeorgRinger/News/ViewHelpers"
+	  xmlns:t3kit="http://typo3.org/ns/T3kit/themeT3kit/ViewHelpers"
 	  data-namespace-typo3-fluid="true">
 
 <f:layout name="General" />
@@ -26,15 +27,7 @@
 				<li>
 					<f:if condition="{category.item.uid} == {overwriteDemand.categories}">
 						<f:then>
-							<f:comment>
-								Set title tag for active category
-							</f:comment>
-							<n:format.nothing>
-								<n:titleTag>
-									<f:format.htmlentitiesDecode><f:cObject typoscriptObjectPath="lib.pageTitle"/> - {category.item.title}</f:format.htmlentitiesDecode>
-								</n:titleTag>
-							</n:format.nothing>
-
+							<t3kit:register key="additionalBreadCrumbItem" value="{category.item.title}"/>
 							<f:link.page title="{category.item.title}" class="active" pageUid="{settings.listPid}"
 											additionalParams="{tx_news_pi1:{overwriteDemand:{categories: category.item.uid}}}">{category.item.title}
 							</f:link.page>

--- a/Resources/Private/Extensions/News/Templates/News/DateMenu.html
+++ b/Resources/Private/Extensions/News/Templates/News/DateMenu.html
@@ -1,5 +1,6 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 	  xmlns:n="http://typo3.org/ns/GeorgRinger/News/ViewHelpers"
+	  xmlns:t3kit="http://typo3.org/ns/T3kit/themeT3kit/ViewHelpers"
 	  data-namespace-typo3-fluid="true">
 
 <f:layout name="General" />
@@ -16,17 +17,12 @@
 					{year}
 					<ul>
 						<f:for each="{months}" key="month" as="count">
+							<f:variable name="monthName">
+								<f:translate key="month.{month}" />
+							</f:variable>
 							<f:if condition="{0:year, 1:month} == {0:overwriteDemand.year, 1:overwriteDemand.month}">
 								<f:then>
-									<f:comment>
-										Set title tag for date menu active item
-									</f:comment>
-									<n:format.nothing>
-										<n:titleTag>
-											<f:format.htmlentitiesDecode><f:cObject typoscriptObjectPath="lib.pageTitle"/> - <f:translate key="month.{month}" /> {year}</f:format.htmlentitiesDecode>
-										</n:titleTag>
-									</n:format.nothing>
-
+									<t3kit:register key="additionalBreadCrumbItem" value="{monthName} {year}"/>
 									<li class="item itemactive">
 										<f:render section="datemenuLink" arguments="{listPid: listPid, year: year, month: month, count: count, entry: entry, entries: entries}"/>
 									</li>

--- a/Resources/Private/Extensions/News/Templates/Tag/List.html
+++ b/Resources/Private/Extensions/News/Templates/Tag/List.html
@@ -1,5 +1,6 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 	  xmlns:n="http://typo3.org/ns/GeorgRinger/News/ViewHelpers"
+	  xmlns:t3kit="http://typo3.org/ns/T3kit/themeT3kit/ViewHelpers"
 	  data-namespace-typo3-fluid="true">
 
 <f:layout name="General" />
@@ -16,14 +17,7 @@
 				<li>
 					<f:if condition="{tag.uid} == {overwriteDemand.tags}">
 						<f:then>
-							<f:comment>
-								Set title tag for active tag
-							</f:comment>
-							<n:format.nothing>
-								<n:titleTag>
-									<f:format.htmlentitiesDecode><f:cObject typoscriptObjectPath="lib.pageTitle"/> - {tag.title}</f:format.htmlentitiesDecode>
-								</n:titleTag>
-							</n:format.nothing>
+							<t3kit:register key="additionalBreadCrumbItem" value="{tag.title}"/>
 							<f:link.page title="{tag.title}" class="active" pageUid="{settings.listPid}" additionalParams="{tx_news_pi1:{overwriteDemand:{tags: tag}}}">
 								{tag.title}
 							</f:link.page>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -35,6 +35,12 @@
 			<trans-unit id="skipLinks.mainContent" xml:space="preserve">
 				<target>Direkt zum Inhalt springen</target>
 			</trans-unit>
+			<trans-unit id="breadcrumb.ariaLabel" xml:space="preserve">
+				<target>Brotkrümelnavigation</target>
+			</trans-unit>
+			<trans-unit id="breadcrumb_label" xml:space="preserve">
+				<target>Sie sind hier</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -13,6 +13,9 @@
 			<trans-unit id="breadcrumb_label" xml:space="preserve">
 				<source>You are here</source>
 			</trans-unit>
+			<trans-unit id="breadcrumb.ariaLabel" xml:space="preserve">
+				<source>Breadcrumb navigation</source>
+			</trans-unit>
 			<trans-unit id="languageMenu_label" xml:space="preserve">
 				<source>Language:</source>
 			</trans-unit>

--- a/Resources/Private/Templates/Theme/Content.html
+++ b/Resources/Private/Templates/Theme/Content.html
@@ -2,13 +2,15 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/Content.html [begin] -->
-
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<f:render partial="Content/Breadcrumbs" section="Default" arguments="{_all}" />
 	<div class="container">
 		<div class="row">
 			<div class="col-md-12">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Theme/ContentMenu.html
+++ b/Resources/Private/Templates/Theme/ContentMenu.html
@@ -2,12 +2,15 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/ContentMenu.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<f:render partial="Content/Breadcrumbs" section="Default" arguments="{_all}" />
 	<div class="container">
 		<div class="row">
 			<div class="col-md-9">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 			<div class="col-md-3">
 				<f:render partial="Content/Menu" section="Default" arguments="{_all}" />

--- a/Resources/Private/Templates/Theme/ContentMenuSidebar.html
+++ b/Resources/Private/Templates/Theme/ContentMenuSidebar.html
@@ -2,12 +2,15 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/ContentMenuSidebar.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<f:render partial="Content/Breadcrumbs" section="Default" arguments="{_all}" />
 	<div class="container">
 		<div class="row">
 			<div class="col-md-6">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 			<div class="col-md-3">
 				<f:render partial="Content/Menu" section="Default" arguments="{_all}" />

--- a/Resources/Private/Templates/Theme/ContentSidebar.html
+++ b/Resources/Private/Templates/Theme/ContentSidebar.html
@@ -2,12 +2,15 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/ContentSidebar.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<f:render partial="Content/Breadcrumbs" section="Default" arguments="{_all}" />
 	<div class="container">
 		<div class="row">
 			<div class="col-md-9">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 			<div class="col-md-3">
 				<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />

--- a/Resources/Private/Templates/Theme/ContentSidebarMenu.html
+++ b/Resources/Private/Templates/Theme/ContentSidebarMenu.html
@@ -2,12 +2,15 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/ContentSidebarMenu.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<f:render partial="Content/Breadcrumbs" section="Default" arguments="{_all}" />
 	<div class="container">
 		<div class="row">
 			<div class="col-md-6">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 			<div class="col-md-3">
 				<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />

--- a/Resources/Private/Templates/Theme/MenuContent.html
+++ b/Resources/Private/Templates/Theme/MenuContent.html
@@ -3,6 +3,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/MenuContent.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<f:render partial="Content/Breadcrumbs" section="Default" arguments="{_all}" />
 
@@ -11,7 +14,7 @@
 			<div class="container">
 				<div class="row">
 					<div class="col-md-9 col-md-push-3">
-						<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+						<f:format.html>{content}</f:format.html>
 					</div>
 					<div class="col-md-3 col-md-pull-9">
 						<f:render partial="Content/Menu" section="Default" arguments="{_all}" />
@@ -23,7 +26,7 @@
 			<div class="container">
 				<div class="row">
 					<div class="col-md-3">
-						<f:render partial="Content/Menu" section="Default" arguments="{_all}" />
+						<f:format.html>{content}</f:format.html>
 					</div>
 					<div class="col-md-9">
 						<f:render partial="Content/Main" section="Default" arguments="{_all}" />

--- a/Resources/Private/Templates/Theme/MenuContentSidebar.html
+++ b/Resources/Private/Templates/Theme/MenuContentSidebar.html
@@ -3,6 +3,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/MenuContentSidebar.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<f:render partial="Content/Breadcrumbs" section="Default" arguments="{_all}" />
 
@@ -11,7 +14,7 @@
 			<div class="container">
 				<div class="row">
 					<div class="col-md-6 col-md-push-3">
-						<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+						<f:format.raw>{content}</f:format.raw>
 					</div>
 					<div class="col-md-3 col-md-push-3">
 						<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />
@@ -29,7 +32,7 @@
 						<f:render partial="Content/Menu" section="Default" arguments="{_all}" />
 					</div>
 					<div class="col-md-6">
-						<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+						<f:format.raw>{content}</f:format.raw>
 					</div>
 					<div class="col-md-3">
 						<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />

--- a/Resources/Private/Templates/Theme/MenuSidebarContent.html
+++ b/Resources/Private/Templates/Theme/MenuSidebarContent.html
@@ -3,6 +3,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/MenuSidebarContent.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<f:render partial="Content/Breadcrumbs" section="Default" arguments="{_all}" />
 
@@ -14,7 +17,7 @@
 						<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />
 					</div>
 					<div class="col-md-6 col-md-push-3">
-						<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+						<f:format.raw>{content}</f:format.raw>
 					</div>
 					<div class="col-md-3 col-md-pull-9">
 						<f:render partial="Content/Menu" section="Default" arguments="{_all}" />
@@ -32,7 +35,7 @@
 						<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />
 					</div>
 					<div class="col-md-6">
-						<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+						<f:format.raw>{content}</f:format.raw>
 					</div>
 				</div>
 			</div>

--- a/Resources/Private/Templates/Theme/SidebarContent.html
+++ b/Resources/Private/Templates/Theme/SidebarContent.html
@@ -2,6 +2,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/SidebarContent.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<f:render partial="Content/Breadcrumbs" section="Default" arguments="{_all}" />
 	<div class="container">
@@ -10,7 +13,7 @@
 				<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />
 			</div>
 			<div class="col-md-9">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Theme/SidebarContentMenu.html
+++ b/Resources/Private/Templates/Theme/SidebarContentMenu.html
@@ -2,6 +2,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/SidebarContentMenu.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<f:render partial="Content/Breadcrumbs" section="Default" arguments="{_all}" />
 	<div class="container">
@@ -10,7 +13,7 @@
 				<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />
 			</div>
 			<div class="col-md-6">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 			<div class="col-md-3">
 				<f:render partial="Content/Menu" section="Default" arguments="{_all}" />

--- a/Resources/Private/Templates/Theme/SidebarMenuContent.html
+++ b/Resources/Private/Templates/Theme/SidebarMenuContent.html
@@ -2,6 +2,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/SidebarMenuContent.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<f:render partial="Content/Breadcrumbs" section="Default" arguments="{_all}" />
 	<div class="container">
@@ -13,7 +16,7 @@
 				<f:render partial="Content/Menu" section="Default" arguments="{_all}" />
 			</div>
 			<div class="col-md-6">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Theme/TopContentContent.html
+++ b/Resources/Private/Templates/Theme/TopContentContent.html
@@ -2,7 +2,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/TopContentContent.html [begin] -->
-
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<div class="top-content">
 		<f:render partial="Content/Top" section="Default" arguments="{_all}" />
@@ -12,7 +14,7 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-12">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Theme/TopContentContentMenu.html
+++ b/Resources/Private/Templates/Theme/TopContentContentMenu.html
@@ -2,6 +2,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/TopContentContentMenu.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<div class="top-content">
 		<f:render partial="Content/Top" section="Default" arguments="{_all}" />
@@ -11,7 +14,7 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-9">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 			<div class="col-md-3">
 				<f:render partial="Content/Menu" section="Default" arguments="{_all}" />

--- a/Resources/Private/Templates/Theme/TopContentContentSidebar.html
+++ b/Resources/Private/Templates/Theme/TopContentContentSidebar.html
@@ -2,6 +2,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/TopContentContentSidebar.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<div class="top-content">
 		<f:render partial="Content/Top" section="Default" arguments="{_all}" />
@@ -11,7 +14,7 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-9">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 			<div class="col-md-3">
 				<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />

--- a/Resources/Private/Templates/Theme/TopContentMenuContent.html
+++ b/Resources/Private/Templates/Theme/TopContentMenuContent.html
@@ -18,7 +18,7 @@
 			<div class="container">
 				<div class="row">
 					<div class="col-md-9 col-md-push-3">
-						<f:format.htmlentitiesDecode>{content}</f:format.htmlentitiesDecode>
+						<f:format.raw>{content}</f:format.raw>
 					</div>
 					<div class="col-md-3 col-md-pull-9">
 						<f:render partial="Content/Menu" section="Default" arguments="{_all}" />

--- a/Resources/Private/Templates/Theme/TopContentMenuContent.html
+++ b/Resources/Private/Templates/Theme/TopContentMenuContent.html
@@ -3,6 +3,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/TopContentMenuContent.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<div class="top-content">
 		<f:render partial="Content/Top" section="Default" arguments="{_all}" />
@@ -15,7 +18,7 @@
 			<div class="container">
 				<div class="row">
 					<div class="col-md-9 col-md-push-3">
-						<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+						<f:format.htmlentitiesDecode>{content}</f:format.htmlentitiesDecode>
 					</div>
 					<div class="col-md-3 col-md-pull-9">
 						<f:render partial="Content/Menu" section="Default" arguments="{_all}" />
@@ -30,7 +33,7 @@
 						<f:render partial="Content/Menu" section="Default" arguments="{_all}" />
 					</div>
 					<div class="col-md-9">
-						<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+						<f:format.raw>{content}</f:format.raw>
 					</div>
 				</div>
 			</div>

--- a/Resources/Private/Templates/Theme/TopContentMenuContentSidebar.html
+++ b/Resources/Private/Templates/Theme/TopContentMenuContentSidebar.html
@@ -3,6 +3,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/TopContentMenuContentSidebar.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<div class="top-content">
 		<f:render partial="Content/Top" section="Default" arguments="{_all}" />
@@ -15,7 +18,7 @@
 			<div class="container">
 				<div class="row">
 					<div class="col-md-6 col-md-push-3">
-						<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+						<f:format.raw>{content}</f:format.raw>
 					</div>
 					<div class="col-md-3 col-md-push-3">
 						<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />
@@ -33,7 +36,7 @@
 						<f:render partial="Content/Menu" section="Default" arguments="{_all}" />
 					</div>
 					<div class="col-md-6">
-						<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+						<f:format.raw>{content}</f:format.raw>
 					</div>
 					<div class="col-md-3">
 						<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />

--- a/Resources/Private/Templates/Theme/TopContentSidebarContent.html
+++ b/Resources/Private/Templates/Theme/TopContentSidebarContent.html
@@ -2,6 +2,9 @@
 	<f:layout name="Default" />
 	<f:section name="Default">
 	<!-- theme_t3kit: Templates/Theme/TopContentSidebarContent.html [begin] -->
+	<f:variable name="content">
+		<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+	</f:variable>
 
 	<div class="top-content">
 		<f:render partial="Content/Top" section="Default" arguments="{_all}" />
@@ -14,7 +17,7 @@
 				<f:render partial="Content/Sidebar" section="Default" arguments="{_all}" />
 			</div>
 			<div class="col-md-9">
-				<f:render partial="Content/Main" section="Default" arguments="{_all}" />
+				<f:format.raw>{content}</f:format.raw>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
I rewrite the breadcrumb navigation, because you used a lot of TypoScript conditions to add additional information, to the breadcrumb.
I implement the solution with a register, so we can use the same implementation for other plugins too, without add some more conditions.