### PR TITLE
Update EventTracking.js

### DIFF
--- a/Resources/Public/JavaScript/EventTracking.js
+++ b/Resources/Public/JavaScript/EventTracking.js
@@ -216,9 +216,11 @@
                     e.preventDefault();
                     var url = $(this).attr('href');
                     tracker.push('_trackEvent', opts.category, opts.action, this.href, opts.value, opts.nonInteraction);
-                    setTimeout(function(){
-                        location.href = url;
-                    }, 250);
+                    if ($(this).data('rel') !== 'popup') {
+                        setTimeout(function(){
+                            location.href = url;
+                        }, 250);
+                    }
                 }
             });
         },


### PR DESCRIPTION
Don't trigger location.href when tracking external links if the data-relation is popup. This fixes that share-links using shariff doesn't also open in the main window.

Shariff uses this parameter on external share-services (which is most of them, like Facebook, Linkedin etc), see https://github.com/heiseonline/shariff/blob/develop/src/js/shariff.js