### PR TITLE
[BUGFIX] expand link of textpic element

### DIFF
--- a/felayout_t3kit/dev/styles/main/typicalContentElements/typicalContentElements.less
+++ b/felayout_t3kit/dev/styles/main/typicalContentElements/typicalContentElements.less
@@ -13,6 +13,11 @@
 // ======== Additional styling for Fluid Styled Content extension  ====
 // ==================================================================
 
+// Make link expand to same size as image to make focus visible on linked images
+.ce-textpic .image a {
+    display: inline-block;
+}
+
 .ce-gallery img {
     display: block;
     height: auto;


### PR DESCRIPTION
Expand the link of textpic element linked images to the same size as the image.
This is necessary to make the focus area visible