### PR TITLE
[BUGFIX] remove css for icon which is never visible

### DIFF
--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -2195,7 +2195,6 @@
 .icon-t3-quoteMark:before { content: "\e0de"; } // quote
 .icon-text-btn__link:after { content: "\e91c"; } // leftIconTextButton
 .icon-text-btn__sham-link:after { content: "\e91c"; } // leftIconTextButton
-.big-icon-text-btn__link:after { content: "\e91c"; } // bigIconTextButton
 .big-icon-text-btn__sham-link:after { content: "\e91c"; } // bigIconTextButton
 .img-text-link__img-link:before { content: "\e943"; } // imageTextLink
 .logo-carousel__btn-next:before { content: '\e91d'; } // logo carousel next


### PR DESCRIPTION
This has to be removed because otherwise it is read by screenreaders.

Please check http://www.t3kit.com/examples/content/content-elements/bigicontextbutton/ to verify that the icon is not visible and the styling can be removed