### PR TITLE
[BUGFIX] Use percentage for top content carousel width

### DIFF
--- a/felayout_t3kit/dev/styles/main/contentElements/bootstrapCarousel.less
+++ b/felayout_t3kit/dev/styles/main/contentElements/bootstrapCarousel.less
@@ -253,7 +253,7 @@
     // Align caption with content
     .top-content {
         .carousel-caption {
-            left: calc(~'(100vw - (@{container-large-desktop} - @{grid-gutter-width})) / 2');
+            left: calc(~'(100% - (@{container-large-desktop} - @{grid-gutter-width})) / 2');
             width: 45%;
         }
     }


### PR DESCRIPTION
The carousel width for the top-content carousel is calculated via css-calc. When using 'vw' for the calculation the results are not correct sometimes. In this case we can just use a percentage, because the top-content is always 100% window width.