### PR TITLE
[BUGFIX] support enlarge on click for CE:s 'Images' and 'Image and text'

### DIFF
--- a/Resources/Private/Partials/FluidStyledContent/Media/Gallery.html
+++ b/Resources/Private/Partials/FluidStyledContent/Media/Gallery.html
@@ -1,0 +1,25 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:ce="http://typo3.org/ns/TYPO3/CMS/FluidStyledContent/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:if condition="{gallery.rows}">
+	<div class="ce-gallery{f:if(condition: data.imageborder, then: ' ce-border')}{f:if(condition:data.image_zoom, then: ' lightbox__wrp-{data.uid}')}" data-ce-columns="{gallery.count.columns}" data-ce-images="{gallery.count.files}">
+		<f:if condition="{gallery.position.horizontal} == 'center'">
+			<div class="ce-outer">
+				<div class="ce-inner">
+		</f:if>
+		<f:for each="{gallery.rows}" as="row">
+			<div class="ce-row">
+				<f:for each="{row.columns}" as="column">
+					<f:if condition="{column.media}">
+						<div class="ce-column">
+							<f:render partial="Media/Type" arguments="{file: column.media, dimensions: column.dimensions, data: data, settings: settings}" />
+						</div>
+					</f:if>
+				</f:for>
+			</div>
+		</f:for>
+		<f:if condition="{gallery.position.horizontal} == 'center'">
+				</div>
+			</div>
+		</f:if>
+	</div>
+</f:if>
+</html>

--- a/Resources/Private/Templates/FluidStyledContent/Textmedia.html
+++ b/Resources/Private/Templates/FluidStyledContent/Textmedia.html
@@ -8,7 +8,7 @@
 
 </f:section>
 <f:section name="Main">
-	<div class="ce-textpic ce-{gallery.position.horizontal} ce-{gallery.position.vertical}{f:if(condition: gallery.position.noWrap, then: ' ce-nowrap')} {f:if(condition:data.image_zoom, then: 'lightbox__wrp-{data.uid}')}">
+	<div class="ce-textpic ce-{gallery.position.horizontal} ce-{gallery.position.vertical}{f:if(condition: gallery.position.noWrap, then: ' ce-nowrap')}">
 		<f:if condition="{gallery.position.vertical} != 'below'">
 			<f:render partial="Media/Gallery" arguments="{_all}" />
 		</f:if>


### PR DESCRIPTION
Move the "lightbox__wrp-" to the "Gallery" Partial which is used in all of "Textmedia", Textpic" and "Image" templates.