### PR TITLE
[FEATURE] New Social Media Option in Theme configuration

### DIFF
--- a/Configuration/ContentElements/SocialIcons.setupts
+++ b/Configuration/ContentElements/SocialIcons.setupts
@@ -12,5 +12,40 @@ tt_content {
             800 < lib.contentElement.dataProcessing.800
             830 < lib.contentElement.dataProcessing.830
         }
+        variables {
+            # set fluid variable "allowLinksFromConstants"
+            # to use as a condition in template if social links from constants are allowed
+            allowLinksFromConstants = TEXT
+            allowLinksFromConstants {
+                # default to "false"
+                value = 0
+                stdWrap {
+                    # override to "true" for default language
+                    override = 1
+                    override {
+                        if {
+                            value = 0
+                            equals.data = TSFE:sys_language_uid
+                        }
+                    }
+                    stdWrap {
+                        # override to "true" for non default languages AND allowFallback is "true"
+                        override = 1
+                        override {
+                            if {
+                                value = 0
+                                isGreaterThan.data = TSFE:sys_language_uid
+                                isTrue.cObject = TEXT
+                                isTrue.cObject {
+                                    value = 1
+                                    if.value = 1
+                                    if.equals = {$themes.configuration.socialmedia.allowFallback}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/Configuration/TypoScript/Library/themes.socialmedia.constantsts
+++ b/Configuration/TypoScript/Library/themes.socialmedia.constantsts
@@ -3,6 +3,7 @@
 #############################################
 
 # #customcategory=socialmedia=Theme: Socialmedia settings
+# customsubcategory=socialmedia_alternatives=Options
 # customsubcategory=socialmedia_facebook=Facebook
 # customsubcategory=socialmedia_twitter=Twitter
 # customsubcategory=socialmedia_linkedin=LinkedIn
@@ -14,6 +15,9 @@
 # customsubcategory=socialmedia_youtube=YouTube
 # customsubcategory=socialmedia_mynewsdesk=Mynewsdesk
 
+# Social Media Options
+# cat=socialmedia,advanced/socialmedia_alternatives/; type=options[Allow=1,Disallow=0]; label= Use these social links as fallback for unset links in translated "Social Icon" CE:s
+themes.configuration.socialmedia.allowFallback = 1
 
 # Facebook
 #############################################

--- a/Resources/Private/Partials/ContentElements/Socialmedia.html
+++ b/Resources/Private/Partials/ContentElements/Socialmedia.html
@@ -4,128 +4,147 @@
 	<f:section name="Default">
 		<!-- theme_t3kit: Partials/Footer/Socialmedia.html [begin] -->
 		<div class="social-icons">
+			<f:comment><!-- facebookLink --></f:comment>
 			<f:if condition="{theme:constant(constant:'themes.configuration.socialmedia.useFacebook')}">
 				<f:if condition="{settings.facebookLink}">
 					<f:then>
-						<a class="social-icons__item" href="{settings.facebookLink}"
-						   target="_blank" title="Facebook" aria-label="Facebook"><span aria-hidden="true" class="icons icon-t3-facebook"></span></a>
+						<f:variable name="facebookLink">{settings.facebookLink}</f:variable>
 					</f:then>
 					<f:else>
-						<a class="social-icons__item" href="{theme:constant(constant:'themes.configuration.socialmedia.facebookLink')}"
-						   target="_blank" title="Facebook" aria-label="Facebook"><span aria-hidden="true" class="icons icon-t3-facebook"></span></a>
+						<f:if condition="{allowLinksFromConstants}">
+							<f:variable name="facebookLink">{theme:constant(constant:'themes.configuration.socialmedia.facebookLink')}</f:variable>
+						</f:if>
 					</f:else>
 				</f:if>
+				<f:render partial="SocialmediaLink" arguments="{linkHref: facebookLink, linkTitle: 'Facebook', iconClass: 'icons icon-t3-facebook'}"/>
 			</f:if>
+			<f:comment><!-- twitterLink --></f:comment>
 			<f:if condition="{theme:constant(constant:'themes.configuration.socialmedia.useTwitter')}">
 				<f:if condition="{settings.twitterLink}">
 					<f:then>
-						<a class="social-icons__item" href="{settings.twitterLink}"
-						   target="_blank" title="Twitter" aria-label="Twitter"><span aria-hidden="true" class="icons icon-t3-twitter"></span></a>
+						<f:variable name="twitterLink">{settings.twitterLink}</f:variable>
 					</f:then>
 					<f:else>
-						<a class="social-icons__item" href="{theme:constant(constant:'themes.configuration.socialmedia.twitterLink')}"
-						   target="_blank" title="Twitter" aria-label="Twitter"><span aria-hidden="true" class="icons icon-t3-twitter"></span></a>
+						<f:if condition="{allowLinksFromConstants}">
+							<f:variable name="twitterLink">{theme:constant(constant:'themes.configuration.socialmedia.twitterLink')}</f:variable>
+						</f:if>
 					</f:else>
 				</f:if>
+				<f:render partial="SocialmediaLink" arguments="{linkHref: twitterLink, linkTitle: 'Twitter', iconClass: 'icons icon-t3-twitter'}"/>
 			</f:if>
+			<f:comment><!-- linkedInLink --></f:comment>
 			<f:if condition="{theme:constant(constant:'themes.configuration.socialmedia.useLinkedIn')}">
 				<f:if condition="{settings.linkedInLink}">
 					<f:then>
-						<a class="social-icons__item" href="{settings.linkedInLink}"
-						   target="_blank" title="LinkedIn" aria-label="LinkedIn"><span aria-hidden="true" class="icons icon-t3-linkedin"></span></a>
+						<f:variable name="linkedInLink">{settings.linkedInLink}</f:variable>
 					</f:then>
 					<f:else>
-						<a class="social-icons__item" href="{theme:constant(constant:'themes.configuration.socialmedia.linkedInLink')}"
-						   target="_blank" title="LinkedIn" aria-label="LinkedIn"><span aria-hidden="true" class="icons icon-t3-linkedin"></span></a>
+						<f:if condition="{allowLinksFromConstants}">
+							<f:variable name="linkedInLink">{theme:constant(constant:'themes.configuration.socialmedia.linkedInLink')}</f:variable>
+						</f:if>
 					</f:else>
 				</f:if>
+				<f:render partial="SocialmediaLink" arguments="{linkHref: linkedInLink, linkTitle: 'LinkedIn', iconClass: 'icons icon-t3-linkedin'}"/>
 			</f:if>
+			<f:comment><!-- xingLink --></f:comment>
 			<f:if condition="{theme:constant(constant:'themes.configuration.socialmedia.useXing')}">
 				<f:if condition="{settings.xingLink}">
 					<f:then>
-						<a class="social-icons__item" href="{settings.xingLink}"
-						   target="_blank" title="Xing" aria-label="Xing"><span aria-hidden="true" class="icons icon-t3-xing"></span></a>
+						<f:variable name="xingLink">{settings.xingLink}</f:variable>
 					</f:then>
 					<f:else>
-						<a class="social-icons__item" href="{theme:constant(constant:'themes.configuration.socialmedia.xingLink')}"
-						   target="_blank" title="Xing" aria-label="Xing"><span aria-hidden="true" class="icons icon-t3-xing"></span></a>
+						<f:if condition="{allowLinksFromConstants}">
+							<f:variable name="xingLink">{theme:constant(constant:'themes.configuration.socialmedia.xingLink')}</f:variable>
+						</f:if>
 					</f:else>
 				</f:if>
+				<f:render partial="SocialmediaLink" arguments="{linkHref: xingLink, linkTitle: 'Xing', iconClass: 'icons icon-t3-xing'}"/>
 			</f:if>
+			<f:comment><!-- vimeoLink --></f:comment>
 			<f:if condition="{theme:constant(constant:'themes.configuration.socialmedia.useVimeo')}">
 				<f:if condition="{settings.vimeoLink}">
 					<f:then>
-						<a class="social-icons__item" href="{settings.vimeoLink}"
-						   target="_blank" title="Vimeo" aria-label="Vimeo"><span aria-hidden="true" class="icons icon-t3-vimeo"></span></a>
+						<f:variable name="vimeoLink">{settings.vimeoLink}</f:variable>
 					</f:then>
 					<f:else>
-						<a class="social-icons__item" href="{theme:constant(constant:'themes.configuration.socialmedia.vimeoLink')}"
-							   target="_blank" title="Vimeo" aria-label="Vimeo"><span aria-hidden="true" class="icons icon-t3-vimeo"></span></a>
+						<f:if condition="{allowLinksFromConstants}">
+							<f:variable name="vimeoLink">{theme:constant(constant:'themes.configuration.socialmedia.vimeoLink')}</f:variable>
+						</f:if>
 					</f:else>
 				</f:if>
+				<f:render partial="SocialmediaLink" arguments="{linkHref: vimeoLink, linkTitle: 'Vimeo', iconClass: 'icons icon-t3-vimeo'}"/>
 			</f:if>
+			<f:comment><!-- googlePlusLink --></f:comment>
 			<f:if condition="{theme:constant(constant:'themes.configuration.socialmedia.useGooglePlus')}">
 				<f:if condition="{settings.googlePlusLink}">
 					<f:then>
-						<a class="social-icons__item" href="{settings.googlePlusLink}"
-						   target="_blank" title="Googleplus" aria-label="Googleplus"><span aria-hidden="true" class="icons icon-t3-googleplus"></span></a>
+						<f:variable name="googlePlusLink">{settings.googlePlusLink}</f:variable>
 					</f:then>
 					<f:else>
-						<a class="social-icons__item" href="{theme:constant(constant:'themes.configuration.socialmedia.googlePlusLink')}"
-							   target="_blank" title="Googleplus" aria-label="Googleplus"><span aria-hidden="true" class="icons icon-t3-googleplus"></span></a>
+						<f:if condition="{allowLinksFromConstants}">
+							<f:variable name="googlePlusLink">{theme:constant(constant:'themes.configuration.socialmedia.googlePlusLink')}</f:variable>
+						</f:if>
 					</f:else>
 				</f:if>
+				<f:render partial="SocialmediaLink" arguments="{linkHref: googlePlusLink, linkTitle: 'Googleplus', iconClass: 'icons icon-t3-googleplus'}"/>
 			</f:if>
+			<f:comment><!-- pinterestLink --></f:comment>
 			<f:if condition="{theme:constant(constant:'themes.configuration.socialmedia.usePinterest')}">
 				<f:if condition="{settings.pinterestLink}">
 					<f:then>
-						<a class="social-icons__item" href="{settings.pinterestLink}"
-						   target="_blank" title="Pinterest" aria-label="Pinterest"><span aria-hidden="true" class="icons icon-t3-pinterest"></span></a>
+						<f:variable name="pinterestLink">{settings.pinterestLink}</f:variable>
 					</f:then>
 					<f:else>
-						<a class="social-icons__item" href="{theme:constant(constant:'themes.configuration.socialmedia.pinterestLink')}"
-							   target="_blank" title="Pinterest" aria-label="Pinterest"><span aria-hidden="true" class="icons icon-t3-pinterest"></span></a>
+						<f:if condition="{allowLinksFromConstants}">
+							<f:variable name="pinterestLink">{theme:constant(constant:'themes.configuration.socialmedia.pinterestLink')}</f:variable>
+						</f:if>
 					</f:else>
 				</f:if>
+				<f:render partial="SocialmediaLink" arguments="{linkHref: pinterestLink, linkTitle: 'Pinterest', iconClass: 'icons icon-t3-pinterest'}"/>
 			</f:if>
+			<f:comment><!-- instagramLink --></f:comment>
 			<f:if condition="{theme:constant(constant:'themes.configuration.socialmedia.useInstagram')}">
 				<f:if condition="{settings.instagramLink}">
 					<f:then>
-						<a class="social-icons__item" href="{settings.instagramLink}"
-						   target="_blank" title="Instagram" aria-label="Instagram"><span aria-hidden="true" class="icons icon-t3-instagram"></span></a>
+						<f:variable name="instagramLink">{settings.instagramLink}</f:variable>
 					</f:then>
 					<f:else>
-						<a class="social-icons__item" href="{theme:constant(constant:'themes.configuration.socialmedia.instagramLink')}"
-							   target="_blank" title="Instagram" aria-label="Instagram"><span aria-hidden="true" class="icons icon-t3-instagram"></span></a>
+						<f:if condition="{allowLinksFromConstants}">
+							<f:variable name="instagramLink">{theme:constant(constant:'themes.configuration.socialmedia.instagramLink')}</f:variable>
+						</f:if>
 					</f:else>
 				</f:if>
+				<f:render partial="SocialmediaLink" arguments="{linkHref: instagramLink, linkTitle: 'Instagram', iconClass: 'icons icon-t3-instagram'}"/>
 			</f:if>
+			<f:comment><!-- youtubeLink --></f:comment>
 			<f:if condition="{theme:constant(constant:'themes.configuration.socialmedia.useYoutube')}">
 				<f:if condition="{settings.youtubeLink}">
 					<f:then>
-						<a class="social-icons__item" href="{settings.youtubeLink}"
-						   target="_blank" title="Youtube" aria-label="Youtube"><span aria-hidden="true" class="icons icon-t3-youtube"></span></a>
+						<f:variable name="youtubeLink">{settings.youtubeLink}</f:variable>
 					</f:then>
 					<f:else>
-						<a class="social-icons__item" href="{theme:constant(constant:'themes.configuration.socialmedia.youtubeLink')}"
-							   target="_blank" title="Youtube" aria-label="Youtube"><span aria-hidden="true" class="icons icon-t3-youtube"></span></a>
+						<f:if condition="{allowLinksFromConstants}">
+							<f:variable name="youtubeLink">{theme:constant(constant:'themes.configuration.socialmedia.youtubeLink')}</f:variable>
+						</f:if>
 					</f:else>
 				</f:if>
+				<f:render partial="SocialmediaLink" arguments="{linkHref: youtubeLink, linkTitle: 'Youtube', iconClass: 'icons icon-t3-youtube'}"/>
 			</f:if>
+			<f:comment><!-- mynewsdeskLink --></f:comment>
 			<f:if condition="{theme:constant(constant:'themes.configuration.socialmedia.useMynewsdesk')}">
 				<f:if condition="{settings.mynewsdeskLink}">
 					<f:then>
-						<a class="social-icons__item" href="{settings.mynewsdeskLink}"
-						   target="_blank" title="Mynewsdesk"><span class="icons icon-t3-mynewsdesk"></span></a>
+						<f:variable name="mynewsdeskLink">{settings.mynewsdeskLink}</f:variable>
 					</f:then>
 					<f:else>
-						<a class="social-icons__item" href="{theme:constant(constant:'themes.configuration.socialmedia.mynewsdeskLink')}"
-							   target="_blank" title="Mynewsdesk"><span class="icons icon-t3-mynewsdesk"></span></a>
+						<f:if condition="{allowLinksFromConstants}">
+							<f:variable name="mynewsdeskLink">{theme:constant(constant:'themes.configuration.socialmedia.mynewsdeskLink')}</f:variable>
+						</f:if>
 					</f:else>
 				</f:if>
+				<f:render partial="SocialmediaLink" arguments="{linkHref: mynewsdeskLink, linkTitle: 'Mynewsdesk', iconClass: 'icons icon-t3-mynewsdesk'}"/>
 			</f:if>
 		</div>
-
 		<!-- theme_t3kit: Partials/Footer/Socialmedia.html [end] -->
 	</f:section>
 </div>

--- a/Resources/Private/Partials/ContentElements/SocialmediaLink.html
+++ b/Resources/Private/Partials/ContentElements/SocialmediaLink.html
@@ -1,0 +1,9 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:if condition="{linkHref}">
+    <f:spaceless>
+        <a class="social-icons__item" href="{linkHref}" target="_blank" title="{linkTitle}" aria-label="{linkTitle}">
+            <span aria-hidden="true" class="{iconClass}"></span>
+        </a>
+    </f:spaceless>
+</f:if>
+</html>

--- a/Resources/Private/Templates/ContentElements/SocialIcons.html
+++ b/Resources/Private/Templates/ContentElements/SocialIcons.html
@@ -4,7 +4,7 @@
 <f:section name="Header" />
 <f:section name="Main">
 <!-- theme_t3kit: Templates/ContentElements/SocialIcons.html [begin] -->
-	<f:render partial="Socialmedia" section="Default" arguments="{settings: settings}"/>
+	<f:render partial="Socialmedia" section="Default" arguments="{settings: settings, allowLinksFromConstants: allowLinksFromConstants}"/>
 <!-- theme_t3kit: Templates/ContentElements/SocialIcons.html [end] -->
 </f:section>
 


### PR DESCRIPTION
Allow/disallow use of constant social links as fallback for unset links in translated "Social Icon" CE:s.

Update socialmedia typoscript, add new fluid variable "allowLinksFromConstants".
Update Socialmedia template to use new template variable in condition.
Add new partial SocialmediaLinks.
Refactor Socialmedia template.