### PR TITLE
Only smaller bg image and contact cards

### DIFF
--- a/Configuration/TypoScript/Library/lib.responsiveBackgroundImage.setupts
+++ b/Configuration/TypoScript/Library/lib.responsiveBackgroundImage.setupts
@@ -57,7 +57,7 @@ page.cssInline {
                     file {
                         import.data = file:current:uid
                         treatIdAsReference = 1
-                        width = 767
+                        maxW = 767
                     }
                 }
 
@@ -70,32 +70,32 @@ page.cssInline {
             20 = TEXT
             20.cObject < .10
             20 {
-                cObject.cObject.file.width = 992px
+                cObject.cObject.file.maxW = 992px
                 noTrimWrap = | @media (min-width: 768px) { | } |
             }
 
             30 = TEXT
             30.cObject < .10
             30 {
-                cObject.cObject.file.width = 1920
+                cObject.cObject.file.maxW = 1920
                 noTrimWrap = | @media (min-width: 992px) { | } |
             }
             60 = TEXT
             60.cObject < .10
             60 {
-                cObject.cObject.file.width = 1000
+                cObject.cObject.file.maxW = 1000
                 noTrimWrap = | @media (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2), (max-width: 767px) and (min-resolution: 2dppx) { | } |
             }
             70 = TEXT
             70.cObject < .10
             70 {
-                cObject.cObject.file.width = 1536
+                cObject.cObject.file.maxW = 1536
                 noTrimWrap = | @media (min-width: 768px) and (-webkit-min-device-pixel-ratio: 2), (min-width: 768px) and (min-resolution: 2dppx) { | } |
             }
             80 = TEXT
             80.cObject < .10
             80 {
-                cObject.cObject.file.width = 2400
+                cObject.cObject.file.maxW = 2400
                 noTrimWrap = | @media (min-width: 992px) and (-webkit-min-device-pixel-ratio: 2), (min-width: 992px) and (min-resolution: 2dppx) { | } |
             }
         }

--- a/Configuration/TypoScript/Library/lib.responsiveBackgroundImage.setupts
+++ b/Configuration/TypoScript/Library/lib.responsiveBackgroundImage.setupts
@@ -70,7 +70,7 @@ page.cssInline {
             20 = TEXT
             20.cObject < .10
             20 {
-                cObject.cObject.file.maxW = 992px
+                cObject.cObject.file.maxW = 992
                 noTrimWrap = | @media (min-width: 768px) { | } |
             }
 

--- a/Configuration/TypoScript/Library/lib.responsiveContactCards.setupts
+++ b/Configuration/TypoScript/Library/lib.responsiveContactCards.setupts
@@ -57,7 +57,7 @@ page.cssInline {
                     file {
                         import.data = file:current:uid
                         treatIdAsReference = 1
-                        width = 212
+                        maxW = 212
                     }
                 }
 
@@ -70,31 +70,31 @@ page.cssInline {
             20 = TEXT
             20.cObject < .10
             20 {
-                cObject.cObject.file.width = 256
+                cObject.cObject.file.maxW = 256
                 noTrimWrap = | @media (max-width: 767px) { | } |
             }
             30 = TEXT
             30.cObject < .10
             30 {
-                cObject.cObject.file.width = 384
+                cObject.cObject.file.maxW = 384
                 noTrimWrap = | @media (min-width: 992px) { | } |
             }
             60 = TEXT
             60.cObject < .10
             60 {
-                cObject.cObject.file.width = 414
+                cObject.cObject.file.maxW = 414
                 noTrimWrap = | @media (max-width: 767px) and (-webkit-min-device-pixel-ratio: 2), (max-width: 767px) and (min-resolution: 2dppx) { | } |
             }
             70 = TEXT
             70.cObject < .10
             70 {
-                cObject.cObject.file.width = 512
+                cObject.cObject.file.maxW = 512
                 noTrimWrap = | @media (min-width: 768px) and (-webkit-min-device-pixel-ratio: 2), (min-width: 768px) and (min-resolution: 2dppx) { | } |
             }
             80 = TEXT
             80.cObject < .10
             80 {
-                cObject.cObject.file.width = 768
+                cObject.cObject.file.maxW = 768
                 noTrimWrap = | @media (min-width: 992px) and (-webkit-min-device-pixel-ratio: 2), (min-width: 992px) and (min-resolution: 2dppx) { | } |
             }
         }


### PR DESCRIPTION
This change results in never upscaling smaller background images (it will be up to the browser instead, based on the already existing styling) in:

(responsive) Contact Card - when Image attribute: "Image as background" is selected.
Grid Elements with responsive background image (including the Parallax version).

This helps when minifying background images (using tinypng or similar) as they are not rescaled upwards by TYPO3.

FYI I tested both elements locally and they "worked fine for me" ;) but ...