### PR TITLE
[FIX] don't create inline-css for background unless value exists.

### DIFF
--- a/Resources/Private/Templates/ContentElements/HeroImage.html
+++ b/Resources/Private/Templates/ContentElements/HeroImage.html
@@ -6,7 +6,7 @@
 <!-- theme_t3kit: Templates/ContentElements/HeroImage.html [begin] -->
 	<f:if condition="{image}">
 		<div class="hero-image js__hero-image {f:cObject(typoscriptObjectPath:'lib.responsiveBackgroundImage', data:image.0.uid)}">
-			<div class="hero-image__caption-wrp {f:if(condition: '{settings.horizontalAlignment} == 0', then: '_left-align')}{f:if(condition: '{settings.horizontalAlignment} == 1', then: '_center-align')}{f:if(condition: '{settings.horizontalAlignment} == 2', then: '_right-align')}" style="height: {settings.elementHeight}px; background-color:{f:if(condition: settings.transparentLayer, then: '{settings.transparentLayer}')};">
+			<div class="hero-image__caption-wrp {f:if(condition: '{settings.horizontalAlignment} == 0', then: '_left-align')}{f:if(condition: '{settings.horizontalAlignment} == 1', then: '_center-align')}{f:if(condition: '{settings.horizontalAlignment} == 2', then: '_right-align')}" style="height: {settings.elementHeight}px;{f:if(condition: settings.transparentLayer, then: ' background-color:{settings.transparentLayer};')}">
 				<div class="hero-image__caption {f:if(condition: '{settings.animationStyle} == 0', then: '', else: '_caption-animated-{settings.animationStyle}')} {f:if(condition: '{settings.verticalAlignment} == 0', then: '_top')}{f:if(condition: '{settings.verticalAlignment} == 2', then: '_bottom')}">
 					<f:if condition="{data.header}">
 						<h2 class="hero-image__caption-header" data-header-content='{data.header}'>{data.header}</h2>


### PR DESCRIPTION
If you don't use the **Element overlay color (rgba)** field in the content element **Hero Image**, the result is some stray inline css:

`<div class="hero-image__caption-wrp _center-align" style="height: 340px; background-color:;">`

This pull request will fix that.