### PR TITLE
[FEATURE] added default column-value in 'Advanced one column grid'.

### DIFF
--- a/Configuration/GridElements/FlexForms/Adv1ColumnGrid.xml
+++ b/Configuration/GridElements/FlexForms/Adv1ColumnGrid.xml
@@ -230,7 +230,7 @@
 													<numIndex index="1">col-md-12</numIndex>
 												</numIndex>
 											</items>
-											<default></default>
+											<default>col-md-12</default>
 									</config>
 							</TCEforms>
 					</column_1_md>


### PR DESCRIPTION
Similar to:
Adv2ColumnGrid
Adv3ColumnGrid
Adv4ColumnGrid

..let's set a default column-value. The main reason being consistency with the other Adv\*ColumnGrid and to ensure that the Bootstrap .row / .col-\*-\* structure is kept.

An example is if you use Adv1ColumnGrid to add a container (both literally and the Bootstrap-terminology .container) in a fluid-container parent, you need to set a .col-\*-\* value as there is also a .row in between of the .container and the .col-\*-\*. Otherwise, the margin / padding structure will not be correct and in mobile view-ports you will typically get a horizontal scrollbar.

So it is for convenience - in the same way as it is for Adv2ColumnGrid and upwards. :) (...and can be overriden completely by users choice)