### PR TITLE
[BUGFIX] make conditions work within INCLUDE_TYPOSCRIPT 

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -17,7 +17,7 @@
 
 # Extensions:
 # News
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Resources/Private/Extensions/News/TypoScript/setup.ts" condition="[userFunc = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('news')]">
+<INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Resources/Private/Extensions/News/TypoScript/setup.ts" condition="[userFunc = TYPO3\\CMS\\Core\\Utility\\ExtensionManagementUtility::isLoaded('news')]">
 
 # Solr
 [userFunc = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('solr')]
@@ -25,17 +25,17 @@
     # Put index queue modifications here, wont work with INCLUDE_TYPOSCRIPT from scheduler task indexer
     plugin.tx_solr.index.queue.news.fields.url.typolink.parameter = {$themes.configuration.features.newsDefaultDetailPid}
 [global]
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Resources/Private/Extensions/Solr/TypoScript/setup.ts" condition="[userFunc = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('solr')]">
+<INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Resources/Private/Extensions/Solr/TypoScript/setup.ts" condition="[userFunc = TYPO3\\CMS\\Core\\Utility\\ExtensionManagementUtility::isLoaded('solr')]">
 
 # cs_seo
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Resources/Private/Extensions/cs_seo/TypoScript/setup.ts" condition="[userFunc = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('cs_seo')]">
+<INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Resources/Private/Extensions/cs_seo/TypoScript/setup.ts" condition="[userFunc = TYPO3\\CMS\\Core\\Utility\\ExtensionManagementUtility::isLoaded('cs_seo')]">
 
 # rx_shariff
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:rx_shariff/Configuration/TypoScript/WithoutJQueryAndFontawesome/setup.txt" condition="[userFunc = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('rx_shariff')]">
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Configuration/TypoScript/Library/plugin.rx_shariff.setupts" condition="[userFunc = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('rx_shariff')]">
+<INCLUDE_TYPOSCRIPT: source="FILE:EXT:rx_shariff/Configuration/TypoScript/WithoutJQueryAndFontawesome/setup.txt" condition="[userFunc = TYPO3\\CMS\\Core\\Utility\\ExtensionManagementUtility::isLoaded('rx_shariff')]">
+<INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Configuration/TypoScript/Library/plugin.rx_shariff.setupts" condition="[userFunc = TYPO3\\CMS\\Core\\Utility\\ExtensionManagementUtility::isLoaded('rx_shariff')]">
 
 # Frontend editing
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Resources/Private/Extensions/FrontendEditing/TypoScript/setup.ts" condition="[userFunc = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('frontend_editing')]">
+<INCLUDE_TYPOSCRIPT: source="FILE:EXT:theme_t3kit/Resources/Private/Extensions/FrontendEditing/TypoScript/setup.ts" condition="[userFunc = TYPO3\\CMS\\Core\\Utility\\ExtensionManagementUtility::isLoaded('frontend_editing')]">
 
 # Include setupTS files from fileadmin/Configuration/TypoScript
 <INCLUDE_TYPOSCRIPT: source="DIR:fileadmin/Configuration/TypoScript/" extensions="setupts">


### PR DESCRIPTION
Need to escape backslashes in condition