### PR TITLE
[!!!][BUGFIX] Fix incorrect class of link in IconTextButton CE,

### DIFF
--- a/Resources/Private/Templates/ContentElements/IconTextButton.html
+++ b/Resources/Private/Templates/ContentElements/IconTextButton.html
@@ -11,7 +11,7 @@
 			Don't want classes btn btn-default when link is on "whole area"
 		-->
 	</f:comment>
-	<f:variable name="anchorClass">{f:if(condition: '{settings.disableWholeAreaLink} != 1 && {settings.btnAsLink} != 1' , then: '', else: ' btn btn-default')}</f:variable>
+	<f:variable name="anchorClass">{f:if(condition: '{settings.disableWholeAreaLink} == 1 && {settings.btnAsLink} != 1' , then: ' btn btn-default', else: '')}</f:variable>
 
 	<div class="icon-text-btn__wrp">
 		<div class="icon-text-btn{f:if(condition: settings.disableWholeAreaLink, then: '', else: ' _whole-area-link')}">


### PR DESCRIPTION
 fixes #419

Breaking since classes "btn btn-default" could be added even if "button as link" was enabled.
Applying this fix might change appearance of IconTextButton CE:s.