### PR TITLE
Page layout word wrap fix

### DIFF
--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -5111,6 +5111,10 @@ div.awesomplete li[aria-selected="true"] mark {
   border: 1px solid #dfe7ea;
   border-width: 0 0 1px;
   font-size: 15px;
+  -webkit-hyphens: auto;
+      -ms-hyphens: auto;
+          hyphens: auto;
+  word-wrap: break-word;
 }
 @media (min-width: 1200px) {
   .sub-navigation__link {

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -8473,6 +8473,9 @@ div.awesomplete li[aria-selected="true"] mark {
     border: 1px solid shade(@sub-navigation-border, 5%);
     border-width: 0 0 1px;
     font-size: 15px;
+    hyphens: auto;
+    // ie11 and edge hyphens polyfill
+    word-wrap: break-word;
 }
 
 @media (min-width: @screen-lg-min) {

--- a/felayout_t3kit/dev/styles/main/nav/subNavigation.less
+++ b/felayout_t3kit/dev/styles/main/nav/subNavigation.less
@@ -30,6 +30,9 @@
     border: 1px solid shade(@sub-navigation-border, 5%);
     border-width: 0 0 1px;
     font-size: 15px;
+    hyphens: auto;
+    // ie11 and edge hyphens polyfill
+    word-wrap: break-word;
 }
 
 @media (min-width: @screen-lg-min) {


### PR DESCRIPTION
Long words in the subnavigation (e.g. in 25%/75% template) do not wrap but flow over the content area. This fix helps to break the words to keep the words in the 25% container.