### PR TITLE
[BUGFIX] jumping animation (clicking the header panel of collapsible)

### DIFF
--- a/Resources/Private/Templates/GridElements/Collapsible.html
+++ b/Resources/Private/Templates/GridElements/Collapsible.html
@@ -22,5 +22,5 @@
 
 <f:section name="accordionLink">
 	<f:link.page pageUid="#collapse-{data.uid}" absolute="1" class="{f:if(condition: data.pi_flexform.data.columns.lDEF.expanded.vDEF, then: '', else: 'collapsed')}"
-				 additionalAttributes="{'data-toggle':'collapse', 'data-target': '#collapse-{data.uid}', 'data-parent': '#group-{data.tx_gridelements_container}'}">{data.header}</f:link.page>
+				 additionalAttributes="{'data-toggle':'collapse', 'data-parent': '#group-{data.tx_gridelements_container}'}">{data.header}</f:link.page>
 </f:section>


### PR DESCRIPTION
We can use a link with the href attribute, or a button with the data-target attribute. 
https://bootstrapdocs.com/v3.3.6/docs/javascript/#collapse

http://t3kit.com/examples/content/content-elements/accordion/  - v2.3.0 accordion works 

https://github.com/t3kit/theme_t3kit/commit/62b6fa737a61be35b1019779ce1ac43d869f4394#diff-c2c6572b17133c6912c61f34c9f8ffd0
https://getbootstrap.com/docs/3.3/javascript/#collapseExample  
 v2.4.0 - these changes add link effect to panel-headers

for exaple -->
http://demo.t3kit.com/content/content-elements/accordion/#collapse-195 - v 2.5.0 accordion doesn’t work 


