### PR TITLE
[BUGFIX] Issues with adding top/bottom margin inside parallax element

### DIFF
--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -4085,6 +4085,12 @@ div.awesomplete li[aria-selected="true"] mark {
   max-width: 1920px;
   margin: 0 auto;
 }
+.parallax:before,
+.parallax:after {
+  content: "";
+  display: table;
+  height: 0;
+}
 @media (min-width: 480px) {
   .no-touch.nonIE .parallax-video {
     background-image: none !important;

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -7104,6 +7104,13 @@ div.awesomplete li[aria-selected="true"] mark {
     background-position: 50% 50%;
     max-width: 1920px;
     margin: 0 auto;
+
+    &:before,
+    &:after {
+        content: "";
+        display: table;
+        height: 0;
+    }
 }
 
 @media (min-width: @screen-xs-min) {

--- a/felayout_t3kit/dev/styles/main/contentElements/parallax.less
+++ b/felayout_t3kit/dev/styles/main/contentElements/parallax.less
@@ -5,6 +5,13 @@
     background-position: 50% 50%;
     max-width: 1920px;
     margin: 0 auto;
+
+    &:before,
+    &:after {
+        content: "";
+        display: table;
+        height: 0;
+    }
 }
 
 @media (min-width: @screen-xs-min) {


### PR DESCRIPTION
 **description**: Created a parallax grid, and inside that an advanced one column grid with text element inside. Now I wanted to add some space above and under column grid to see more of parallax image. But the system adds it to the parallax image instead.

**solution:** We can fix this in many ways: adding inline styles "overflow: hidden" or "display: grid" to parallax element. But it can have side-effects on the content you put inside parallax gridElement. The best solution is to add pseudo-elements that will count margins added in typo3. 