### PR TITLE
[BUGFIX] increase line-heingt of header in Icon_text_btn CE

### DIFF
--- a/felayout_t3kit/dev/styles/main/contentElements/leftIconTextButton.less
+++ b/felayout_t3kit/dev/styles/main/contentElements/leftIconTextButton.less
@@ -9,6 +9,10 @@
     margin: 0 -15px;
 }
 
+.icon-text-btn__header {
+    line-height: 1.6;
+}
+
 .icon-text-btn__icon {
     padding: 10px;
     border: 2px solid tint(@main-color, 70%);


### PR DESCRIPTION
**Description:** When the headline in the Icon, Text and Button content element takes more than two lines (three for example) the distance between the lines is not the same.

![screenshot 2018-06-25 12 26 28](https://user-images.githubusercontent.com/17538897/41842282-067735cc-7873-11e8-9423-8d2ac9af6a06.png)
