### PR TITLE
[TASK] remove news teaser link  news-cards__more-link (read more link)

### DIFF
--- a/Resources/Private/Extensions/News/Partials/List/Cards.html
+++ b/Resources/Private/Extensions/News/Partials/List/Cards.html
@@ -100,11 +100,6 @@
 
 				</div>
 			</n:link>
-			<div class="news-cards__more-link">
-				<n:link newsItem="{newsItem}" settings="{settings}" class="more" additionalAttributes="{aria-label: '{f:translate(key:\'news.more-link.linktext\', extensionName:\'Theme_t3kit\')}{newsItem.title}'}" title="{f:translate(key:'news.more-link.linktext', extensionName:'Theme_t3kit')}{newsItem.title}">
-					<f:translate key="more-link"/>
-				</n:link>
-			</div>
 
 			<!-- author -->
 			<f:if condition="{newsItem.author}">

--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -2099,9 +2099,6 @@
   padding: 10px 15px;
   background-color: #e6e6e6;
 }
-.news-cards__more-link {
-  padding: 12px 15px;
-}
 .news-cards__header h3 {
   font-size: 22px;
 }

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -4683,10 +4683,6 @@
     background-color: darken(@main-body-bg, 10%);
 }
 
-.news-cards__more-link {
-    padding: 12px 15px;
-}
-
 .news-cards__header h3 {
     font-size: 22px;
 }

--- a/felayout_t3kit/dev/styles/main/plugins/news/newsCards.less
+++ b/felayout_t3kit/dev/styles/main/plugins/news/newsCards.less
@@ -22,10 +22,6 @@
     background-color: darken(@main-body-bg, 10%);
 }
 
-.news-cards__more-link {
-    padding: 12px 15px;
-}
-
 .news-cards__header h3 {
     font-size: 22px;
 }


### PR DESCRIPTION
.news-cards__item has a link so the element .news-cards__more-link is unnecessary