### PR TITLE
[BUGFIX] use bootstrap collapsible with correct element selectors

### DIFF
--- a/Resources/Private/Templates/GridElements/Collapsible.html
+++ b/Resources/Private/Templates/GridElements/Collapsible.html
@@ -21,6 +21,6 @@
 </f:section>
 
 <f:section name="accordionLink">
-	<f:link.page pageUid="#collapse-{data.uid}" absolute="1" class="{f:if(condition: data.pi_flexform.data.columns.lDEF.expanded.vDEF, then: '', else: 'collapsed')}"
-				 additionalAttributes="{'data-toggle':'collapse', 'data-parent': '#group-{data.tx_gridelements_container}'}">{data.header}</f:link.page>
+	<f:link.external uri="#collapse-{data.uid}" defaultScheme="" class="{f:if(condition: data.pi_flexform.data.columns.lDEF.expanded.vDEF, then: '', else: 'collapsed')}"
+									 additionalAttributes="{'data-toggle':'collapse', 'data-parent': '#group-{data.tx_gridelements_container}'}">{data.header}</f:link.external>
 </f:section>

--- a/Resources/Private/Templates/GridElements/Collapsible.html
+++ b/Resources/Private/Templates/GridElements/Collapsible.html
@@ -21,6 +21,14 @@
 </f:section>
 
 <f:section name="accordionLink">
-	<f:link.external uri="#collapse-{data.uid}" defaultScheme="" class="{f:if(condition: data.pi_flexform.data.columns.lDEF.expanded.vDEF, then: '', else: 'collapsed')}"
-									 additionalAttributes="{'data-toggle':'collapse', 'data-parent': '#group-{data.tx_gridelements_container}'}">{data.header}</f:link.external>
+	<button
+		type="button"
+		class="{f:if(condition: data.pi_flexform.data.columns.lDEF.expanded.vDEF, then: '', else: 'collapsed')}"
+		data-toggle="collapse"
+		data-target="#collapse-{data.uid}"
+		data-parent="#group-{data.tx_gridelements_container}"
+		aria-expanded="{f:if(condition: data.pi_flexform.data.columns.lDEF.expanded.vDEF, then: 'true', else: 'false')}"
+	>
+		{data.header}
+	</button>
 </f:section>


### PR DESCRIPTION
Previously the URL generated by
```html
<f:link.page pageUid="#collapse-{data.uid}" absolute="1" class="{f:if(condition: data.pi_flexform.data.columns.lDEF.expanded.vDEF, then: '', else: 'collapsed')}"
			 additionalAttributes="{'data-toggle':'collapse', 'data-parent': '#group-{data.tx_gridelements_container}'}">{data.header}</f:link.page>
```
was something like "https://domain.name/some/path/#collapse-351", which did not sit well with bootstrap.

This resulted in the `collapsed` class not being set and removed on the a-tag correctly, thus destroying styles which relied on the class.

My fix now generates URLs like "#collapse-352", which works fine.

I don't really like the solution using `link.external`, but I could not find a way to do the same using `f:link.page`. If there is any, please suggest it.