### PR TITLE
[BUGFIX] HTML Citation element <cite> replacement to <span>

### DIFF
--- a/Resources/Private/Templates/ContentElements/Quote.html
+++ b/Resources/Private/Templates/ContentElements/Quote.html
@@ -16,13 +16,13 @@
 				<span class="quote__footer-name">{headers.0}<f:render section="nameSuffix" arguments="{title: headers.1, link: data.header_link}" /></span>
 			</f:if>
 			<f:if condition="{headers.1}">
-				<cite class="quote__footer-title" title="{headers.1}">{headers.1}<f:render section="nameSuffix" arguments="{link: data.header_link}" />
+				<span class="quote__footer-title" title="{headers.1}">{headers.1}<f:render section="nameSuffix" arguments="{link: data.header_link}" />
 			</f:if>
 			<f:if condition="{data.header_link}">
 				<f:link.typolink parameter="{data.header_link}" class="quote__footer-link">{data.subheader}</f:link.typolink>
 			</f:if>
 			<f:if condition="{headers.1}">
-				</cite>
+				</span>
 			</f:if>
 		</footer>
 	</blockquote>


### PR DESCRIPTION
The <cite> element identifies the source of a quotation or creative work. Use the element to identify the name rather than the author or creator of a referenced creative work.
"The HTML Citation element (<cite>) is used to describe a reference to a cited creative work, and must include either the title or author or the URL of that work. The reference may be in an abbreviated form according to context-appropriate conventions related to citation metadata."
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite