### PR TITLE
[FEATURE] Add white-space normal on buttons update css/less

### DIFF
--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -5625,6 +5625,7 @@ h2 {
   color: #fff;
   background-color: #50b4d8;
   border-color: transparent;
+  white-space: normal;
 }
 .btn-default:focus,
 .btn-default:hover {
@@ -5636,6 +5637,7 @@ h2 {
   color: #50b4d8;
   background-color: #fff;
   border-color: transparent;
+  white-space: normal;
 }
 .btn-default--inverted:focus,
 .btn-default--inverted:hover {
@@ -5647,6 +5649,7 @@ h2 {
   color: #50b4d8;
   background-color: transparent;
   border-color: #50b4d8;
+  white-space: normal;
 }
 .btn-bordered:focus,
 .btn-bordered:hover {
@@ -5658,6 +5661,7 @@ h2 {
   color: #fff;
   background-color: transparent;
   border-color: #fff;
+  white-space: normal;
 }
 .btn-bordered--inverted:focus,
 .btn-bordered--inverted:hover {

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -1973,6 +1973,7 @@
     color: @color;
     background-color: @background;
     border-color: @border;
+    white-space: normal;
 
     &:focus,
     &:hover {

--- a/felayout_t3kit/dev/styles/main/mixins.less
+++ b/felayout_t3kit/dev/styles/main/mixins.less
@@ -50,6 +50,7 @@
     color: @color;
     background-color: @background;
     border-color: @border;
+    white-space: normal;
 
     &:focus,
     &:hover {


### PR DESCRIPTION
On the mobile view at the button the text does not break when it is too long.

- Icon, Text and Button
- Image text and link
- Slider
<img width="375" alt="slider" src="https://user-images.githubusercontent.com/40461747/51673674-e22f8580-1fce-11e9-8e44-cf25c2a78808.png">
<img width="376" alt="imgtext" src="https://user-images.githubusercontent.com/40461747/51673692-efe50b00-1fce-11e9-88e9-dd6516f6a875.png">


