### PR TITLE
[BUGFIX] correct TYPO3 and PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,11 @@ notifications:
 language: php
 
 php:
-  - 7.0
-  - 7.1
+  - 7.2
 
 env:
   matrix:
-    - TYPO3_VERSION=~8.7
+    - TYPO3_VERSION=~9.5
 
 sudo: false
 
@@ -33,7 +32,7 @@ before_install:
   - composer --version
 
 before_script:
-  - composer require typo3/cms="$TYPO3_VERSION"
+  - composer require typo3/minimal="$TYPO3_VERSION"
   # Restore composer.json
   - git checkout composer.json
   - export TYPO3_PATH_WEB=$PWD/.Build/Web


### PR DESCRIPTION
Currently pullrequest tests always fail bacause the TYPO3 and the php version does not fit the requirements. This is the fix for this.