### PR TITLE
Remove double tab functionality for better accessibility

### DIFF
--- a/Resources/Private/Extensions/News/Partials/List/NewsCarousel.html
+++ b/Resources/Private/Extensions/News/Partials/List/NewsCarousel.html
@@ -2,106 +2,103 @@
 <div class="news-list-view news-carousel {f:format.case(value: '{settings.templateLayout}', mode: 'lower')}">
 	<button aria-hidden="true" class="js__news-carousel__btn-prev news-carousel__btn-prev swiper-button-prev"></button>
 	<div class="swiper-container news-carousel__container js__news-carousel">
-	<!-- Additional required wrapper -->
 		<ul class="swiper-wrapper news-carousel__wrapper">
 			<f:for each="{news}" as="newsItem" iteration="iterator">
 
-			<li class="swiper-slide news-carousel__slide">
-				<article class="article articletype-{newsItem.type}{f:if(condition: newsItem.istopnews, then: ' topnews')}" itemscope="itemscope" itemtype="http://schema.org/Article">
-					<n:excludeDisplayedNews newsItem="{newsItem}"/>
+				<li class="swiper-slide news-carousel__slide">
+					<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
+						<article class="article articletype-{newsItem.type}{f:if(condition: newsItem.istopnews, then: ' topnews')}" itemscope="itemscope" itemtype="http://schema.org/Article">
+							<n:excludeDisplayedNews newsItem="{newsItem}"/>
 
-					<f:if condition="{newsItem.mediaPreviews}">
-						<!-- media preview element -->
-						<f:then>
-							<div class="news-carousel__img-wrap">
-								<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
-									<f:alias map="{mediaElement: '{newsItem.mediaPreviews.0}'}">
-										<f:if condition="{mediaElement.originalResource.type} == 2">
-											<div class="news-carousel__media-preview">
-												<f:media file="{mediaElement}" class="object-fit" style="height:{f:if(condition:settings.media.maxHeight, then: settings.media.maxHeight, else: settings.list.media.image.maxHeight)}px"/>
-											</div>
-										</f:if>
-										<f:if condition="{mediaElement.originalResource.type} == 4">
-											<f:render partial="Detail/MediaVideo" arguments="{mediaElement: mediaElement}"/>
-										</f:if>
-										<f:if condition="{mediaElement.originalResource.type} == 5">
-											<div class="news-carousel__media-preview">
-												<f:media file="{mediaElement}" class="object-fit" style="height:{f:if(condition:settings.media.maxHeight, then: settings.media.maxHeight, else: settings.list.media.image.maxHeight)}px"/>
-											</div>
-										</f:if>
-									</f:alias>
-								</n:link>
+							<f:if condition="{newsItem.mediaPreviews}">
+								<f:comment>Media preview element</f:comment>
+								<f:then>
+									<div class="news-carousel__img-wrap">
 
-								<div class="news-carousel__item-info">
-									<f:if condition="{newsItem.firstCategory}">
-											<!-- first category -->
-											<span class="news-list-category">{newsItem.firstCategory.title}</span>
+											<f:alias map="{mediaElement: '{newsItem.mediaPreviews.0}'}">
+												<f:if condition="{mediaElement.originalResource.type} == 2">
+													<div class="news-carousel__media-preview">
+														<f:media file="{mediaElement}" class="object-fit" width="355" style="height:{f:if(condition:settings.media.maxHeight, then: settings.media.maxHeight, else: settings.list.media.image.maxHeight)}px" />
+													</div>
+												</f:if>
+												<f:if condition="{mediaElement.originalResource.type} == 4">
+													<f:render partial="Detail/MediaVideo" arguments="{mediaElement: mediaElement}"/>
+												</f:if>
+												<f:if condition="{mediaElement.originalResource.type} == 5">
+													<div class="news-carousel__media-preview">
+														<f:media file="{mediaElement}" class="object-fit" width="355" style="height:{f:if(condition:settings.media.maxHeight, then: settings.media.maxHeight, else: settings.list.media.image.maxHeight)}px" />
+													</div>
+												</f:if>
+											</f:alias>
+
+											<div class="news-carousel__item-info">
+												<f:if condition="{newsItem.firstCategory}">
+													<f:comment>First category</f:comment>
+													<span class="news-list-category">{newsItem.firstCategory.title}</span>
+												</f:if>
+												<f:comment>Date</f:comment>
+												<span class="news-list-date">
+													<time datetime="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}">
+														<meta itemprop="datePublished" content="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}" />
+														<f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date>
+													</time>
+												</span>
+											</div>
+
+									</div>
+								</f:then>
+								<f:else>
+									<f:if condition="{settings.displayDummyIfNoMedia}">
+										<div class="news-carousel__img-wrap">
+
+												<div class="no-media-element" aria-hidden="true">
+													<div class="news-carousel__media-preview">
+														<f:image src="{settings.list.media.dummyImage}" class="img-responsive object-fit" title="" alt="" style="background-image:url('{f:uri.image(src: settings.list.media.dummyImage, treatIdAsReference: 1)}');
+                      height:{f:if(condition:settings.media.maxHeight, then: settings.media.maxHeight, else: settings.list.media.image.maxHeight)}px"></f:image>
+													</div>
+												</div>
+
+												<div class="news-carousel__item-info">
+													<f:if condition="{newsItem.firstCategory}">
+														<f:comment>First category</f:comment>
+														<span class="news-list-category">{newsItem.firstCategory.title}</span>
+													</f:if>
+													<f:comment>Date</f:comment>
+													<span class="news-list-date">
+														<time datetime="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}">
+															<meta itemprop="datePublished" content="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}" />
+															<f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date>
+														</time>
+													</span>
+												</div>
+
+										</div>
 									</f:if>
-									<!-- date -->
-									<span class="news-list-date">
-										<time datetime="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}">
-											<meta itemprop="datePublished" content="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}" />
-											<f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date>
-										</time>
-									</span>
-								</div>
-
-							</div>
-						</f:then>
-						<f:else>
-							<f:if condition="{settings.displayDummyIfNoMedia}">
-								<div class="news-carousel__img-wrap">
-									<div class="no-media-element" aria-hidden="true">
-										<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
-											<div class="news-carousel__media-preview">
-												<f:image src="{settings.list.media.dummyImage}" class="img-responsive object-fit" title="" alt="" style="height:{f:if(condition:settings.media.maxHeight, then: settings.media.maxHeight, else: settings.list.media.image.maxHeight)}px" />
-											</div>
-										</n:link>
-									</div>
-
-									<div class="news-carousel__item-info">
-										<f:if condition="{newsItem.firstCategory}">
-												<!-- first category -->
-												<span class="news-list-category">{newsItem.firstCategory.title}</span>
-										</f:if>
-										<!-- date -->
-										<span class="news-list-date">
-											<time datetime="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}">
-												<meta itemprop="datePublished" content="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}" />
-												<f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date>
-											</time>
-										</span>
-									</div>
-
-								</div>
+								</f:else>
 							</f:if>
-						</f:else>
-					</f:if>
 
-					<!-- header -->
-					<div class="news-article-header">
-						<h3>
-							<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
-								<span itemprop="headline">{newsItem.title}</span>
-							</n:link>
-						</h3>
-					</div>
+							<f:comment>Header</f:comment>
+							<div class="news-article-header">
+								<h3>
+									<span itemprop="headline">{newsItem.title}</span>
+								</h3>
+							</div>
 
-					<!-- teaser -->
-					<div class="teaser-text">
-						<f:if condition="{newsItem.teaser}">
-							<f:then>
-								<div itemprop="description">{newsItem.teaser -> f:format.crop(maxCharacters: '{settings.newsCarousel.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</div>
-							</f:then>
-							<f:else>
-								<div itemprop="description">{newsItem.bodytext -> f:format.crop(maxCharacters: '{settings.newsCarousel.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</div>
-							</f:else>
-						</f:if>
-					</div>
+							<f:comment>Teaser</f:comment>
+							<div class="teaser-text">
+								<f:if condition="{newsItem.teaser}">
+									<f:then>
+										<div itemprop="description">{newsItem.teaser -> f:format.crop(maxCharacters: '{settings.newsCarousel.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</div>
+									</f:then>
+									<f:else>
+										<div itemprop="description">{newsItem.bodytext -> f:format.crop(maxCharacters: '{settings.newsCarousel.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</div>
+									</f:else>
+								</f:if>
+							</div>
 
-				</article>
-
-			</li>
+						</article>
+					</n:link>
+				</li>
 
 			</f:for>
 		</ul>

--- a/Resources/Private/Extensions/News/Partials/List/SimpleList.html
+++ b/Resources/Private/Extensions/News/Partials/List/SimpleList.html
@@ -19,86 +19,81 @@
 
 
 <f:section name="simpleList">
-	<article class="news-simple-list__item clearfix articletype-{newsItem.type}{f:if(condition: newsItem.istopnews, then: ' topnews')}" itemscope="itemscope" itemtype="http://schema.org/Article">
+	<article class="TOTEST news-simple-list__item clearfix articletype-{newsItem.type}{f:if(condition: newsItem.istopnews, then: ' topnews')}" itemscope="itemscope" itemtype="http://schema.org/Article">
 		<n:excludeDisplayedNews newsItem="{newsItem}"/>
-
-		<f:if condition="{newsItem.mediaPreviews}">
-			<!-- media preview element -->
-			<f:then>
-				<div class="news-simple-list__img-wrap">
-					<n:link newsItem="{newsItem}" settings="{settings}" additionalAttributes="{aria-label: '{f:translate(key:\'news.more-link.linktext\', extensionName:\'Theme_t3kit\')}{newsItem.title}'}" title="{f:translate(key:'news.more-link.linktext', extensionName:'Theme_t3kit')}{newsItem.title}">
-						<f:alias map="{mediaElement: '{newsItem.mediaPreviews.0}'}">
-							<f:if condition="{mediaElement.originalResource.type} == 2">
-								<div class="news-simple-list__media-preview">
-									<f:media file="{mediaElement}" class="object-fit"/>
-								</div>
-							</f:if>
-							<f:if condition="{mediaElement.originalResource.type} == 4">
-								<f:media file="{mediaElement}" additionalConfig="{loop: '0', autoplay: '0'}" />
-							</f:if>
-							<f:if condition="{mediaElement.originalResource.type} == 5">
-								<div class="news-simple-list__media-preview">
-									<f:media file="{mediaElement}" class="object-fit"/>
-								</div>
-							</f:if>
-						</f:alias>
-					</n:link>
-				</div>
-			</f:then>
-			<f:else>
-				<f:if condition="{settings.displayDummyIfNoMedia}">
+		<n:link class="news-simple-list__link" newsItem="{newsItem}" settings="{settings}" additionalAttributes="{aria-label: '{f:translate(key:\'news.more-link.linktext\', extensionName:\'Theme_t3kit\')}{newsItem.title}'}" title="{f:translate(key:'news.more-link.linktext', extensionName:'Theme_t3kit')}{newsItem.title}">
+			<f:if condition="{newsItem.mediaPreviews}">
+				<f:comment>Media preview element</f:comment>
+				<f:then>
 					<div class="news-simple-list__img-wrap">
-						<div class="no-media-element">
-							<n:link newsItem="{newsItem}" settings="{settings}" title="{f:translate(key:'news.more-link.linktext', extensionName:'Theme_t3kit')}{newsItem.title}">
+							<f:alias map="{mediaElement: '{newsItem.mediaPreviews.0}'}">
+								<f:if condition="{mediaElement.originalResource.type} == 2">
+									<div class="news-simple-list__media-preview">
+										<f:media file="{mediaElement}" class="object-fit"/>
+									</div>
+								</f:if>
+								<f:if condition="{mediaElement.originalResource.type} == 4">
+									<f:media file="{mediaElement}" additionalConfig="{loop: '0', autoplay: '0'}" />
+								</f:if>
+								<f:if condition="{mediaElement.originalResource.type} == 5">
+									<div class="news-simple-list__media-preview">
+										<f:media file="{mediaElement}" class="object-fit"/>
+									</div>
+								</f:if>
+							</f:alias>
+					</div>
+				</f:then>
+				<f:else>
+					<f:if condition="{settings.displayDummyIfNoMedia}">
+						<div class="news-simple-list__img-wrap">
+							<div class="no-media-element">
 								<div class="news-simple-list__media-preview">
 									<f:image src="{settings.list.media.dummyImage}" class="img-responsive object-fit" title="" alt="" />
 								</div>
-							</n:link>
+							</div>
 						</div>
-					</div>
-				</f:if>
-			</f:else>
-		</f:if>
-
-		<div class="news-simple-list__text js__news-simple-list__dotdotdot">
-
-			<!-- date -->
-			<span class="news-list-date news-simple-list__date-wrp">
-				<span class="news-simple-list__date-text">
-					<f:translate extensionName="Theme_t3kit" key="news.date.text"/>
-				</span>
-				<span class="news-simple-list__date">
-					<time datetime="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}">
-						<f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date>
-						<meta itemprop="datePublished" content="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}" />
-					</time>
-				</span>
-			</span>
-
-			<!-- header -->
-			<f:if condition="{newsItem.title}">
-				<div class="news-article-header news-simple-list__header">
-					<h3>{newsItem.title}</h3>
-				</div>
+					</f:if>
+				</f:else>
 			</f:if>
 
+			<div class="news-simple-list__text js__news-simple-list__dotdotdot">
 
-			<!-- teaser -->
-			<div class="teaser-text news-simple-list__teaser">
-				<f:if condition="{newsItem.teaser}">
-					<f:then>
-						<div itemprop="description">{newsItem.teaser -> f:format.crop(maxCharacters: '{settings.simpleList.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</div>
-					</f:then>
-					<f:else>
-						<div itemprop="description">{newsItem.bodytext -> f:format.crop(maxCharacters: '{settings.simpleList.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</div>
-					</f:else>
+				<f:comment>Date</f:comment>
+				<span class="news-list-date news-simple-list__date-wrp">
+					<span class="news-simple-list__date-text">
+						<f:translate extensionName="Theme_t3kit" key="news.date.text"/>
+					</span>
+					<span class="news-simple-list__date">
+						<time datetime="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}">
+							<f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date>
+							<meta itemprop="datePublished" content="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}" />
+						</time>
+					</span>
+				</span>
+
+				<f:comment>Header</f:comment>
+				<f:if condition="{newsItem.title}">
+					<div class="news-article-header news-simple-list__header">
+						<h3>{newsItem.title}</h3>
+					</div>
 				</f:if>
+
+
+				<f:comment>Teaser</f:comment>
+				<div class="teaser-text news-simple-list__teaser">
+					<f:if condition="{newsItem.teaser}">
+						<f:then>
+							<div itemprop="description">{newsItem.teaser -> f:format.crop(maxCharacters: '{settings.simpleList.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</div>
+						</f:then>
+						<f:else>
+							<div itemprop="description">{newsItem.bodytext -> f:format.crop(maxCharacters: '{settings.simpleList.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</div>
+						</f:else>
+					</f:if>
+				</div>
 			</div>
-		</div>
-		<div class="news-simple-list__more-link">
-			<n:link newsItem="{newsItem}" settings="{settings}" class="more" title="{f:translate(key:'news.more-link.linktext', extensionName:'Theme_t3kit')}{newsItem.title}">
+			<div class="news-simple-list__more-text">
 				<f:translate key="more-link"/>
-			</n:link>
-		</div>
+			</div>
+		</n:link>
 	</article>
 </f:section>

--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -1465,6 +1465,7 @@
   height: 0;
   clear: both;
   visibility: hidden;
+  position: absolute;
 }
 .news .article .news-img-wrap {
   float: left;
@@ -1484,6 +1485,9 @@
 }
 .news .article .teaser-text {
   margin: 0 0 10px;
+}
+.news .teaser-text {
+  color: #7d7d7d;
 }
 .news .footer {
   clear: both;
@@ -1828,6 +1832,9 @@
 .news-categories li li:before {
   color: #bbb;
 }
+.news-list-date {
+  color: #7d7d7d;
+}
 .news-article-footer {
   background: none;
   border: none;
@@ -1925,8 +1932,62 @@
 .news-carousel__img-wrap {
   position: relative;
 }
+.news-carousel__img-wrap:before,
+.news-carousel__img-wrap:after {
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.5s ease, visibility 0.5s ease;
+}
+.news-carousel__img-wrap:before {
+  /* use !important to prevent issues with browser extensions that change fonts */
+  font-family: 'icons' !important;
+  speak: none;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: '\e943';
+  font-size: 38px;
+  color: #eef8fb;
+  border: 2px solid #eef8fb;
+  border-radius: 50%;
+  top: 50%;
+  left: 50%;
+  padding: 12px;
+  margin-left: -33px;
+  margin-top: -33px;
+  z-index: 110;
+}
+.news-carousel__img-wrap:after {
+  content: '';
+  display: block;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #50b4d8;
+  z-index: 10;
+}
+.news-carousel__img-wrap:hover:before {
+  opacity: 1;
+  visibility: visible;
+}
+.news-carousel__img-wrap:hover:after {
+  opacity: 0.7;
+  visibility: visible;
+}
 .news-carousel__slide .news-article-header h3 {
   font-size: 18px;
+  color: #50b4d8;
+  text-decoration: none;
+}
+.news-carousel__slide .news-article-header h3:hover {
+  color: #85cbe4;
 }
 .news-carousel__item-info {
   z-index: 90;
@@ -2030,57 +2091,6 @@
 .news-carousel__pagination .swiper-pagination-bullet-active {
   background: #50b4d8;
 }
-.news-carousel__img-wrap a:after {
-  content: '';
-  top: 0;
-  left: 0;
-  z-index: 10;
-  width: 100%;
-  height: 100%;
-  display: block;
-  position: absolute;
-  background: #50b4d8;
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.5s ease, visibility 0.5s ease;
-}
-.news-carousel__img-wrap a:hover:after,
-.news-carousel__img-wrap a:focus:after {
-  opacity: 0.7;
-  visibility: visible;
-}
-.news-carousel__img-wrap a:before {
-  /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: 'icons' !important;
-  speak: none;
-  font-style: normal;
-  font-weight: normal;
-  font-variant: normal;
-  text-transform: none;
-  line-height: 1;
-  /* Better Font Rendering =========== */
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  position: absolute;
-  font-size: 38px;
-  padding: 12px;
-  border: 2px solid #eef8fb;
-  border-radius: 50%;
-  top: 50%;
-  left: 50%;
-  margin-left: -33px;
-  margin-top: -33px;
-  z-index: 110;
-  color: #eef8fb;
-  opacity: 0;
-  visibility: hidden;
-  content: '\e943';
-  transition: opacity 0.5s ease, visibility 0.5s ease;
-}
-.news-carousel__img-wrap a:hover:before {
-  opacity: 1;
-  visibility: visible;
-}
 .news-cards__item {
   position: relative;
   box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.15);
@@ -2136,14 +2146,22 @@
   position: relative;
   padding: 15px 15px 0;
   height: auto;
-}
-.news-simple-list__more-link {
-  padding: 0 15px 15px;
+  color: #7d7d7d;
 }
 .news-simple-list__header h3 {
   font-size: 22px;
 }
+.news-simple-list__more-text {
+  color: #50b4d8;
+  padding: 0 15px 15px;
+}
+.news-simple-list__more-text:hover {
+  color: #85cbe4;
+}
 @media (min-width: 768px) {
+  .news-simple-list__link {
+    display: inline-block;
+  }
   .news-simple-list__img-wrap {
     float: left;
     width: 290px;
@@ -2155,7 +2173,7 @@
     padding-top: 20px;
     padding-right: 30px;
   }
-  .news-simple-list__more-link {
+  .news-simple-list__more-text {
     padding: 0;
   }
 }

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -3988,6 +3988,8 @@
     height: 0;
     clear: both;
     visibility: hidden;
+    // fix outline containing the pseudo element
+    position: absolute;
 }
 
 .news .article .news-img-wrap {
@@ -4014,8 +4016,8 @@
     margin: 0 0 10px;
 }
 
-.news .article h3 {
-    // margin-bottom: 0;
+.news .teaser-text {
+    color: #7d7d7d;
 }
 
 .news .footer {
@@ -4373,6 +4375,10 @@
     color: #bbb;
 }
 
+.news-list-date {
+    color: @main-text-color;
+}
+
 .news-article-footer {
     background: none;
     border: none;
@@ -4494,12 +4500,64 @@
 
 .news-carousel__img-wrap {
     position: relative;
+
+    &:before,
+    &:after {
+        position: absolute;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.5s ease, visibility 0.5s ease;
+    }
+
+    &:before {
+        .icons();
+
+        content: '\e943';
+        font-size: 38px;
+        color: tint(@main-color, 90%);
+        border: 2px solid tint(@main-color, 90%);
+        border-radius: 50%;
+        top: 50%;
+        left: 50%;
+        padding: 12px;
+        margin-left: -33px;
+        margin-top: -33px;
+        z-index: 110;
+    }
+
+    &:after {
+        content: '';
+        display: block;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: @main-color;
+        z-index: 10;
+    }
+
+    &:hover:before {
+        opacity: 1;
+        visibility: visible;
+    }
+
+    &:hover:after {
+        opacity: 0.7;
+        visibility: visible;
+    }
 }
 
 //header
 .news-carousel__slide .news-article-header h3 {
     font-size: 18px;
+    color: @main-link-color;
+    text-decoration: none;
+
+    &:hover {
+        color: #85cbe4;
+    }
 }
+
 //info
 .news-carousel__item-info {
     z-index: 90;
@@ -4613,52 +4671,6 @@
     background: @main-color;
 }
 
-.news-carousel__img-wrap a:after {
-    content: '';
-    top: 0;
-    left: 0;
-    z-index: 10;
-    width: 100%;
-    height: 100%;
-    display: block;
-    position: absolute;
-    background: @main-color;
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.5s ease, visibility 0.5s ease;
-}
-
-.news-carousel__img-wrap a:hover:after,
-.news-carousel__img-wrap a:focus:after {
-    opacity: 0.7;
-    visibility: visible;
-}
-
-.news-carousel__img-wrap a:before {
-    .icons();
-
-    position: absolute;
-    font-size: 38px;
-    padding: 12px;
-    border: 2px solid tint(@main-color, 90%);
-    border-radius: 50%;
-    top: 50%;
-    left: 50%;
-    margin-left: -33px;
-    margin-top: -33px;
-    z-index: 110;
-    color: tint(@main-color, 90%);
-    opacity: 0;
-    visibility: hidden;
-    content: '\e943';
-    transition: opacity 0.5s ease, visibility 0.5s ease;
-}
-
-.news-carousel__img-wrap a:hover:before {
-    opacity: 1;
-    visibility: visible;
-}
-
 // Cards
 
 .news-cards__item {
@@ -4728,17 +4740,28 @@
     position: relative;
     padding: 15px 15px 0;
     height: auto;
-}
-
-.news-simple-list__more-link {
-    padding: 0 15px 15px;
+    color: @main-text-color;
 }
 
 .news-simple-list__header h3 {
     font-size: 22px;
 }
 
+.news-simple-list__more-text {
+    color: @main-link-color;
+    padding: 0 15px 15px;
+
+    &:hover {
+        color: #85cbe4;
+    }
+}
+
 @media (min-width: @screen-sm-min) {
+    .news-simple-list__link {
+        // outline fix
+        display: inline-block;
+    }
+
     .news-simple-list__img-wrap {
         float: left;
         width: 290px;
@@ -4752,7 +4775,7 @@
         padding-right: 30px;
     }
 
-    .news-simple-list__more-link {
+    .news-simple-list__more-text {
         padding: 0;
     }
 }

--- a/felayout_t3kit/dev/styles/main/plugins/news/news.less
+++ b/felayout_t3kit/dev/styles/main/plugins/news/news.less
@@ -46,6 +46,8 @@
     height: 0;
     clear: both;
     visibility: hidden;
+    // fix outline containing the pseudo element
+    position: absolute;
 }
 
 .news .article .news-img-wrap {
@@ -72,8 +74,8 @@
     margin: 0 0 10px;
 }
 
-.news .article h3 {
-    // margin-bottom: 0;
+.news .teaser-text {
+    color: #7d7d7d;
 }
 
 .news .footer {
@@ -429,6 +431,10 @@
 
 .news-categories li li:before {
     color: #bbb;
+}
+
+.news-list-date {
+    color: @main-text-color;
 }
 
 .news-article-footer {

--- a/felayout_t3kit/dev/styles/main/plugins/news/newsCarousel.less
+++ b/felayout_t3kit/dev/styles/main/plugins/news/newsCarousel.less
@@ -31,12 +31,64 @@
 
 .news-carousel__img-wrap {
     position: relative;
+
+    &:before,
+    &:after {
+        position: absolute;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.5s ease, visibility 0.5s ease;
+    }
+
+    &:before {
+        .icons();
+
+        content: '\e943';
+        font-size: 38px;
+        color: tint(@main-color, 90%);
+        border: 2px solid tint(@main-color, 90%);
+        border-radius: 50%;
+        top: 50%;
+        left: 50%;
+        padding: 12px;
+        margin-left: -33px;
+        margin-top: -33px;
+        z-index: 110;
+    }
+
+    &:after {
+        content: '';
+        display: block;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: @main-color;
+        z-index: 10;
+    }
+
+    &:hover:before {
+        opacity: 1;
+        visibility: visible;
+    }
+
+    &:hover:after {
+        opacity: 0.7;
+        visibility: visible;
+    }
 }
 
 //header
 .news-carousel__slide .news-article-header h3 {
     font-size: 18px;
+    color: @main-link-color;
+    text-decoration: none;
+
+    &:hover {
+        color: #85cbe4;
+    }
 }
+
 //info
 .news-carousel__item-info {
     z-index: 90;
@@ -148,50 +200,4 @@
 
 .news-carousel__pagination .swiper-pagination-bullet-active {
     background: @main-color;
-}
-
-.news-carousel__img-wrap a:after {
-    content: '';
-    top: 0;
-    left: 0;
-    z-index: 10;
-    width: 100%;
-    height: 100%;
-    display: block;
-    position: absolute;
-    background: @main-color;
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.5s ease, visibility 0.5s ease;
-}
-
-.news-carousel__img-wrap a:hover:after,
-.news-carousel__img-wrap a:focus:after {
-    opacity: 0.7;
-    visibility: visible;
-}
-
-.news-carousel__img-wrap a:before {
-    .icons();
-
-    position: absolute;
-    font-size: 38px;
-    padding: 12px;
-    border: 2px solid tint(@main-color, 90%);
-    border-radius: 50%;
-    top: 50%;
-    left: 50%;
-    margin-left: -33px;
-    margin-top: -33px;
-    z-index: 110;
-    color: tint(@main-color, 90%);
-    opacity: 0;
-    visibility: hidden;
-    content: '\e943';
-    transition: opacity 0.5s ease, visibility 0.5s ease;
-}
-
-.news-carousel__img-wrap a:hover:before {
-    opacity: 1;
-    visibility: visible;
 }

--- a/felayout_t3kit/dev/styles/main/plugins/news/newsSimpleList.less
+++ b/felayout_t3kit/dev/styles/main/plugins/news/newsSimpleList.less
@@ -18,17 +18,28 @@
     position: relative;
     padding: 15px 15px 0;
     height: auto;
-}
-
-.news-simple-list__more-link {
-    padding: 0 15px 15px;
+    color: @main-text-color;
 }
 
 .news-simple-list__header h3 {
     font-size: 22px;
 }
 
+.news-simple-list__more-text {
+    color: @main-link-color;
+    padding: 0 15px 15px;
+
+    &:hover {
+        color: #85cbe4;
+    }
+}
+
 @media (min-width: @screen-sm-min) {
+    .news-simple-list__link {
+        // outline fix
+        display: inline-block;
+    }
+
     .news-simple-list__img-wrap {
         float: left;
         width: 290px;
@@ -42,7 +53,7 @@
         padding-right: 30px;
     }
 
-    .news-simple-list__more-link {
+    .news-simple-list__more-text {
         padding: 0;
     }
 }


### PR DESCRIPTION
Wraps news simple list elements and news carousel elements in a single link to prevent double tabbing. 
This improves accessibility and also the usability for normal users, making the whole news element clickable.