### PR TITLE
[TASK] rebuild how the language menu is rendered, respect site configuration

### DIFF
--- a/Classes/DataProcessing/LanguageMenuProcessor.php
+++ b/Classes/DataProcessing/LanguageMenuProcessor.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace T3kit\themeT3kit\DataProcessing;
+
+/**
+ * Extend original class with menuLevelConfig
+ *
+ * @package T3kit\themeT3kit\DataProcessing
+ */
+class LanguageMenuProcessor extends \TYPO3\CMS\Frontend\DataProcessing\LanguageMenuProcessor
+{
+    /**
+     * Initialize
+     * Extend original configuration
+     */
+    public function __construct()
+    {
+        $additionalMenuConfig = [
+            'stdWrap.' => [
+                'cObject.' => [
+                    '25' => 'USER',
+                    '25.' => [
+                        'userFunc' => 'TYPO3\CMS\Frontend\DataProcessing\LanguageMenuProcessor->getFieldAsJson',
+                        'language.' => [
+                            'data' => 'register:languageId'
+                        ],
+                        'field' => 'flagIdentifier',
+                        'stdWrap.' => [
+                            'wrap' => ',"flagIdentifier":|',
+                            'replacement.' => [
+                                '10.' => [
+                                    'search' => 'flags-',
+                                    'replace' => ''
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $this->menuLevelConfig = array_merge_recursive($this->menuLevelConfig, $additionalMenuConfig);
+
+        parent::__construct();
+    }
+}

--- a/Configuration/TypoScript/Library/lib.menu.language.standard.setupts
+++ b/Configuration/TypoScript/Library/lib.menu.language.standard.setupts
@@ -1,25 +1,12 @@
 lib.menu.language.standard =< lib.contentElement
 lib.menu.language.standard {
     templateName = LanguageMenuStandard
-    variables {
-        defaultLanguageIsoCode = TEXT
-        defaultLanguageIsoCode.value = {$themes.languages.default.isoCodeShort}
-        defaultLanguageFlag = TEXT
-        defaultLanguageFlag.value = {$themes.languages.default.flag}
-        defaultLanguageLabel = TEXT
-        defaultLanguageLabel.value = {$themes.languages.default.label}
-    }
+
     dataProcessing {
-        10 = TYPO3\CMS\Frontend\DataProcessing\LanguageMenuProcessor
+        10 = T3kit\themeT3kit\DataProcessing\LanguageMenuProcessor
         10 {
-           languages = auto
+           languages = 0,{$themes.languages.available}
            as = languages
-        }
-        20 = TYPO3\CMS\Frontend\DataProcessing\DatabaseQueryProcessor
-        20 {
-            table = sys_language
-            pidInList = root
-            as = sysLanguages
         }
     }
 }

--- a/Resources/Private/Templates/FluidStyledContent/LanguageMenuStandard.html
+++ b/Resources/Private/Templates/FluidStyledContent/LanguageMenuStandard.html
@@ -1,45 +1,28 @@
-{namespace theme=KayStrobach\Themes\ViewHelpers}
-
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:theme="http://typo3.org/ns/KayStrobach/Themes/ViewHelpers"
+      data-namespace-typo3-fluid="true">
 <f:if condition="{languages}">
-	<div class="header-top__language-menu">
-		<f:for each="{languages}" as="language">
-			<f:variable name="languageFlag"><f:spaceless><f:render section="getLanguageFlag" arguments="{_all}" /></f:spaceless></f:variable>
-			<f:if condition="{language.active}">
-				<a class="header-top__language-menu-btn js__header-top__language-menu-btn" href="/#"><span class="main-flag-icon flag-icon flag-icon-{languageFlag}"></span><f:if condition="{theme:constant(constant:'themes.configuration.elem.status.showHeaderTopLangLabel')}">
-					<span class="main-flag-language flag-language">{f:translate(key:'languageMenu_label', extensionName:'theme_t3kit')}</span>
-				</f:if></a>
-			</f:if>
-		</f:for>
-		<div class="header-top__language-menu-box js__header-top__language-menu-box">
-			<f:for each="{languages}" as="language">
-			<f:variable name="languageFlag"><f:spaceless><f:render section="getLanguageFlag" arguments="{_all}" /></f:spaceless></f:variable>
-				<f:link.page addQueryString="1"
-							 additionalParams="{L: language.languageId}"
-							 title="{language.title}"
-							 class="header-top__language-menu-box-item{f:if(condition: language.active, then: ' active')}"
-							 argumentsToBeExcludedFromQueryString="{0: 'id'}"><f:spaceless>
-						<span class="flag-icon flag-icon-{languageFlag}"></span> {language.navigationTitle}
-				</f:spaceless></f:link.page>
-			</f:for>
-			<button class="header-top__language-menu-box-close-btn js__header-top__language-menu-box-close-btn"></button>
-		</div>
-	</div>
+    <div class="header-top__language-menu">
+        <f:for each="{languages}" as="language">
+            <f:if condition="{language.active}">
+                <a class="header-top__language-menu-btn js__header-top__language-menu-btn" href="/#">
+                    <span class="main-flag-icon flag-icon flag-icon-{language.flagIdentifier}"></span>
+                    <f:if condition="{theme:constant(constant:'themes.configuration.elem.status.showHeaderTopLangLabel')}">
+                        <span class="main-flag-language flag-language">{f:translate(key:'languageMenu_label', extensionName:'ThemeT3kit')}</span>
+                    </f:if>
+                </a>
+            </f:if>
+        </f:for>
+        <div class="header-top__language-menu-box js__header-top__language-menu-box">
+            <f:for each="{languages}" as="language">
+                <a href="{language.link}"
+                   title="{language.title}"
+                   class="header-top__language-menu-box-item{f:if(condition: language.active, then: ' active')}">
+                    <span class="flag-icon flag-icon-{language.flagIdentifier}"></span> {language.navigationTitle}
+                </a>
+            </f:for>
+            <button class="header-top__language-menu-box-close-btn js__header-top__language-menu-box-close-btn"></button>
+        </div>
+    </div>
 </f:if>
-
-<f:comment><!-- need to have current language in language variable --></f:comment>
-<f:section name="getLanguageFlag">
-	<f:variable name="getLanguageFlag">unknown</f:variable>
-	<f:if condition="{language.languageId} == 0">
-		<f:then>
-			<f:variable name="getLanguageFlag">{defaultLanguageFlag}</f:variable>
-		</f:then>
-		<f:else>
-			<f:for each="{sysLanguages}" as="sysLanguage">
-				<f:if condition="{sysLanguage.data.uid} == {language.languageId}">
-					<f:variable name="getLanguageFlag">{sysLanguage.data.flag}</f:variable>
-				</f:if>
-			</f:for>
-		</f:else>
-	</f:if>
-	{getLanguageFlag}
-</f:section>
+</html>


### PR DESCRIPTION
1. Avoid using of "themes" constants for default language setup.
2. Use site configuration language settings for flags and default language. 