### PR TITLE
[BUGFIX] news-single page navigation 'next record link' aligned to le…

### DIFF
--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -1580,7 +1580,6 @@
 .news-single .page-navigation__prev,
 .news-single .page-navigation__next {
   width: 50%;
-  float: left;
   position: relative;
 }
 .news-single .page-navigation__prev:before,
@@ -1591,6 +1590,7 @@
   top: 2px;
 }
 .news-single .page-navigation__next {
+  float: right;
   text-align: right;
   padding: 0 25px 0 15px;
 }
@@ -1618,6 +1618,7 @@
   right: 0;
 }
 .news-single .page-navigation__prev {
+  float: left;
   padding: 0 15px 0 25px;
 }
 .news-single .page-navigation__prev:before,

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -4135,7 +4135,6 @@
         &__prev,
         &__next {
             width: 50%;
-            float: left;
             position: relative;
 
             &:before,
@@ -4146,6 +4145,7 @@
         }
 
         &__next {
+            float: right;
             text-align: right;
             padding: 0 25px 0 15px;
 
@@ -4157,6 +4157,7 @@
         }
 
         &__prev {
+            float: left;
             padding: 0 15px 0 25px;
 
             .link-arrow--circle();

--- a/felayout_t3kit/dev/styles/main/plugins/news/news.less
+++ b/felayout_t3kit/dev/styles/main/plugins/news/news.less
@@ -190,7 +190,6 @@
         &__prev,
         &__next {
             width: 50%;
-            float: left;
             position: relative;
 
             &:before,
@@ -201,6 +200,7 @@
         }
 
         &__next {
+            float: right;
             text-align: right;
             padding: 0 25px 0 15px;
 
@@ -212,6 +212,7 @@
         }
 
         &__prev {
+            float: left;
             padding: 0 15px 0 25px;
 
             .link-arrow--circle();


### PR DESCRIPTION
…ft when no 'previous record link'.

Fixed with styling and tested in IE11, Edge 18, Chrome, FF.

![Selection_328](https://user-images.githubusercontent.com/12510409/55390268-242cf880-5537-11e9-9040-660917beca6d.png)