### PR TITLE
[BUGFIX] search button / box responsive issues.

### DIFF
--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -389,7 +389,7 @@
 @media (min-width: 768px) {
   .header-middle__logo {
     float: left;
-    width: 40%;
+    width: auto;
     text-align: left;
   }
   .header-middle__logo-link {
@@ -859,6 +859,16 @@
     display: none;
   }
 }
+.header-top-wrp .tx-solr-searchbox,
+.main-navigation .tx-solr-searchbox {
+  position: relative;
+  float: right;
+}
+@media (max-width: 991px) {
+  .header-top-wrp .tx-solr-searchbox {
+    position: initial;
+  }
+}
 .main-navigation__search-btn-wrp {
   display: none;
   float: right;
@@ -1028,25 +1038,20 @@
 .main-navigation__search-box {
   position: relative;
   height: 60px;
-  width: 100%;
-  top: 0;
+  width: 100vw;
+  bottom: 0;
   left: auto;
   right: 0;
   z-index: 3000;
 }
 @media (min-width: 992px) {
   .main-navigation__search-box {
-    width: 46%;
+    width: 450px;
     position: absolute;
     right: 60px;
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.3s 0s, visibility 0s 0.3s;
-  }
-}
-@media (min-width: 1200px) {
-  .main-navigation__search-box {
-    width: 36%;
   }
 }
 .main-navigation__search-box._search-box-visible {
@@ -4138,7 +4143,7 @@ div.awesomplete li[aria-selected="true"] mark {
 @media (min-width: 768px) {
   .header-middle__social-icon .social-icons {
     float: right;
-    width: 60%;
+    width: auto;
     text-align: right;
     padding: 0 10px 0 0;
     height: 110px;

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -2646,7 +2646,7 @@
 @media (min-width: @screen-sm-min) {
     .header-middle__logo {
         float: left;
-        width: 40%;
+        width: auto;
         text-align: left;
     }
 
@@ -3195,6 +3195,21 @@
 // =================================
 // Search
 
+// .tx-solr-searchbox contains .main-navigation__search-btn and .main-navigation__search-box
+// by setting it to relative position, the search-field can now float (responsive)
+.header-top-wrp .tx-solr-searchbox,
+.main-navigation .tx-solr-searchbox {
+    position: relative;
+    float: right;
+}
+
+@media (max-width: @screen-sm-max) {
+    // removes relative position to make header-top searchbox full width
+    .header-top-wrp .tx-solr-searchbox {
+        position: initial;
+    }
+}
+
 .main-navigation__search-btn-wrp {
     display: none;
     float: right;
@@ -3395,33 +3410,22 @@
 .main-navigation__search-box {
     position: relative;
     height: @nav-height;
-    width: 100%;
-    top: 0;
+    width: 100vw;
+    bottom: 0;
     left: auto;
     right: 0;
     z-index: 3000;
 }
 
-@media (min-width: @screen-sm-min) {
-    .main-navigation__search-box {
-        // width: 50%;
-    }
-}
-
 @media (min-width: @screen-md-min) {
+    // search-box in both header-top and main-navigation
     .main-navigation__search-box {
-        width: 46%;
+        width: 450px;
         position: absolute;
         right: 60px;
         opacity: 0;
         visibility: hidden;
         transition: opacity 0.3s 0s, visibility 0s 0.3s;
-    }
-}
-
-@media (min-width: @screen-lg-min) {
-    .main-navigation__search-box {
-        width: 36%;
     }
 }
 
@@ -7177,7 +7181,7 @@ div.awesomplete li[aria-selected="true"] mark {
 @media (min-width: @screen-sm-min) {
     .header-middle__social-icon .social-icons {
         float: right;
-        width: 60%;
+        width: auto;
         text-align: right;
         padding: 0 10px 0 0;
         height: @header-middle-height;

--- a/felayout_t3kit/dev/styles/main/contentElements/socialIcons.less
+++ b/felayout_t3kit/dev/styles/main/contentElements/socialIcons.less
@@ -68,7 +68,7 @@
 @media (min-width: @screen-sm-min) {
     .header-middle__social-icon .social-icons {
         float: right;
-        width: 60%;
+        width: auto;
         text-align: right;
         padding: 0 10px 0 0;
         height: @header-middle-height;

--- a/felayout_t3kit/dev/styles/main/header/header.less
+++ b/felayout_t3kit/dev/styles/main/header/header.less
@@ -348,7 +348,7 @@
 @media (min-width: @screen-sm-min) {
     .header-middle__logo {
         float: left;
-        width: 40%;
+        width: auto;
         text-align: left;
     }
 
@@ -897,6 +897,21 @@
 // =================================
 // Search
 
+// .tx-solr-searchbox contains .main-navigation__search-btn and .main-navigation__search-box
+// by setting it to relative position, the search-field can now float (responsive)
+.header-top-wrp .tx-solr-searchbox,
+.main-navigation .tx-solr-searchbox {
+    position: relative;
+    float: right;
+}
+
+@media (max-width: @screen-sm-max) {
+    // removes relative position to make header-top searchbox full width
+    .header-top-wrp .tx-solr-searchbox {
+        position: initial;
+    }
+}
+
 .main-navigation__search-btn-wrp {
     display: none;
     float: right;
@@ -1097,33 +1112,22 @@
 .main-navigation__search-box {
     position: relative;
     height: @nav-height;
-    width: 100%;
-    top: 0;
+    width: 100vw;
+    bottom: 0;
     left: auto;
     right: 0;
     z-index: 3000;
 }
 
-@media (min-width: @screen-sm-min) {
-    .main-navigation__search-box {
-        // width: 50%;
-    }
-}
-
 @media (min-width: @screen-md-min) {
+    // search-box in both header-top and main-navigation
     .main-navigation__search-box {
-        width: 46%;
+        width: 450px;
         position: absolute;
         right: 60px;
         opacity: 0;
         visibility: hidden;
         transition: opacity 0.3s 0s, visibility 0s 0.3s;
-    }
-}
-
-@media (min-width: @screen-lg-min) {
-    .main-navigation__search-box {
-        width: 36%;
     }
 }
 


### PR DESCRIPTION
- search-button in main-navigation is hidden under search-box when language-menu-box is enabled.
- search-box in header-middle doesn't fit when social-icons are enabled.

Some t3kit components in main-navigation or header-middle work fine by themselves but not in combination with others. This pull request tries to solve search-box related issues above. It also changes **header-middle__logo** and **header-middle__social-icon** to width: auto; in 768px screens or larger (or logo + searchbox + social icons will simply not fit).

Testing:

I have tried to test as much as I can to not break other things / other views, but I need a second opinion whether this is deemed [!!!] or not. The following images are showing before, after, before, after my pull request is applied.

**Testcase 1:**
Shows the issue where search-button in main-navigation is hidden under search-box when language-menu-box is enabled. (see **Desktop 2**-image)

**Typoscript constants:**
themes.configuration.isDevelopment = 1
themes.configuration.menu.main.enableLangMenuInNavigation = 1
themes.configuration.elem.status.showHeaderTopSearch = 1
themes.configuration.elem.status.showHeaderTopLangMenu = 1
themes.configuration.elem.status.showHeaderMainMenuSearch = 1
themes.configuration.elem.status.showHeaderTopLangLabel = 1
themes.configuration.elem.status.headerTopNavigationVisibleInMobileMenu = 1

**themes.configuration.elem.status.showHeaderMiddleSearch = 0
themes.configuration.elem.status.showHeaderMiddleSocIcons = 0**

themes.configuration.socialmedia.useGooglePlus = 0
themes.configuration.socialmedia.useMynewsdesk = 0
themes.configuration.socialmedia.usePinterest = 0
themes.configuration.socialmedia.useTwitter = 1
themes.configuration.socialmedia.useVimeo = 0
themes.configuration.socialmedia.useXing = 0
themes.configuration.socialmedia.useYoutube = 1

Desktop 1
![testcase1_desktop1_0](https://user-images.githubusercontent.com/12510409/55886669-7b247480-5bac-11e9-90dc-3ca46514cfc1.png)
![testcase1_desktop1_1_fixed](https://user-images.githubusercontent.com/12510409/55886670-7bbd0b00-5bac-11e9-8a7d-12c7038b22e5.png)

Desktop 2
![testcase1_desktop2_0](https://user-images.githubusercontent.com/12510409/55886671-7bbd0b00-5bac-11e9-878f-0f64f075c232.png)
![testcase1_desktop2_1_fixed](https://user-images.githubusercontent.com/12510409/55886672-7bbd0b00-5bac-11e9-8b01-12f76134d4b6.png)

iPad 1
![testcase1_ipad_1_0](https://user-images.githubusercontent.com/12510409/55886673-7bbd0b00-5bac-11e9-8db2-f74c749b3f2e.png)
![testcase1_ipad_1_1_fixed](https://user-images.githubusercontent.com/12510409/55886674-7c55a180-5bac-11e9-8f43-cafadd257852.png)

iPad 2
![testcase1_ipad_2_0](https://user-images.githubusercontent.com/12510409/55886675-7c55a180-5bac-11e9-9b6b-16ea5cf7c6bb.png)
![testcase1_ipad_2_1_fixed](https://user-images.githubusercontent.com/12510409/55886676-7c55a180-5bac-11e9-8ed3-c47d7f9094cc.png)

iPad 3
![testcase1_ipad_3_0](https://user-images.githubusercontent.com/12510409/55886678-7c55a180-5bac-11e9-923d-90c689aa0e31.png)
![testcase1_ipad_3_1_fixed](https://user-images.githubusercontent.com/12510409/55886679-7cee3800-5bac-11e9-8e48-b5081b3d531f.png)

**Testcase 2:**
Shows the issue that search-box in header-middle doesn't fit when social-icons are enabled.

**Typoscript constants:**
themes.configuration.isDevelopment = 1
themes.configuration.menu.main.enableLangMenuInNavigation = 1
themes.configuration.elem.status.showHeaderTopSearch = 1
themes.configuration.elem.status.showHeaderTopLangMenu = 1
themes.configuration.elem.status.showHeaderMainMenuSearch = 1
themes.configuration.elem.status.showHeaderTopLangLabel = 1
themes.configuration.elem.status.headerTopNavigationVisibleInMobileMenu = 1

**themes.configuration.elem.status.showHeaderMiddleSearch = 1
themes.configuration.elem.status.showHeaderMiddleSocIcons = 1**

themes.configuration.socialmedia.useGooglePlus = 0
themes.configuration.socialmedia.useMynewsdesk = 0
themes.configuration.socialmedia.usePinterest = 0
themes.configuration.socialmedia.useTwitter = 1
themes.configuration.socialmedia.useVimeo = 0
themes.configuration.socialmedia.useXing = 0
themes.configuration.socialmedia.useYoutube = 1

Desktop 1
![testcase2_desktop_1_0](https://user-images.githubusercontent.com/12510409/55886718-8f687180-5bac-11e9-9ba7-e4ec87ec4545.png)
![testcase2_desktop_1_1_fixed](https://user-images.githubusercontent.com/12510409/55886719-90010800-5bac-11e9-825d-b107af12cb5e.png)

Desktop 2
![testcase2_desktop_2_0](https://user-images.githubusercontent.com/12510409/55886720-90010800-5bac-11e9-8540-5f3e34485666.png)
![testcase2_desktop_2_1_fixed](https://user-images.githubusercontent.com/12510409/55886722-90010800-5bac-11e9-9223-c24e0b0d4dde.png)

iPad 1
![testcase2_ipad_1_0](https://user-images.githubusercontent.com/12510409/55886723-90010800-5bac-11e9-92e3-e31dc867a007.png)
![testcase2_ipad_1_1_fixed](https://user-images.githubusercontent.com/12510409/55886725-90010800-5bac-11e9-9d72-2768d3260cf9.png)

iPad 2
![testcase2_ipad_2_0](https://user-images.githubusercontent.com/12510409/55886726-90999e80-5bac-11e9-8890-1d7abce2a927.png)
![testcase2_ipad_2_1_fixed](https://user-images.githubusercontent.com/12510409/55886727-90999e80-5bac-11e9-929f-457862c03ad7.png)

iPad 3
![testcase2_ipad_3_0](https://user-images.githubusercontent.com/12510409/55886728-90999e80-5bac-11e9-95cd-cbd217338702.png)
![testcase2_ipad_3_1_fixed](https://user-images.githubusercontent.com/12510409/55886731-91cacb80-5bac-11e9-9131-db063eb20151.png)
