### PR TITLE
solr search button - issue when clicking before js loaded

### DIFF
--- a/Resources/Private/Extensions/Solr/HeaderTopSearch/Partials/Search/Form.html
+++ b/Resources/Private/Extensions/Solr/HeaderTopSearch/Partials/Search/Form.html
@@ -13,12 +13,11 @@
 		</f:if>
 
 		<div class="main-navigation__search-btn-wrp _header-top-search-btn">
-				<a class="main-navigation__search-btn js__main-navigation__search-btn" href="">{s:translate(key:'submit',default:'Search')}<span></span></a>
+			<a class="main-navigation__search-btn js__main-navigation__search-btn" href="#">{s:translate(key:'submit',default:'Search')}<span></span></a>
 		</div>
 		<div class="main-navigation__search-box _header-top-search-btn js__main-navigation__search-box" >
-			<input type="search" id="inputText" class="tx-solr-q js-solr-q" name="{pluginNamespace}[q]" value="{q}" placeholder="{s:translate(key:'submit',default:'Search')}"  data-search="searchSuggest"  data-search="searchSuggest" />
+			<input type="search" id="inputText" class="tx-solr-q js-solr-q" name="{pluginNamespace}[q]" value="{q}" placeholder="{s:translate(key:'submit',default:'Search')}" data-search="searchSuggest" />
 		</div>
-
 	</s:searchForm>
 
 	<s:debug.query />

--- a/Resources/Private/Extensions/Solr/MenuMainSearch/Partials/Search/Form.html
+++ b/Resources/Private/Extensions/Solr/MenuMainSearch/Partials/Search/Form.html
@@ -13,7 +13,7 @@
 		</f:if>
 
 		<div class="main-navigation__search-btn-wrp">
-			<a class="main-navigation__search-btn js__main-navigation__search-btn" href="">{s:translate(key:'submit',default:'Search')}<span></span></a>
+			<a class="main-navigation__search-btn js__main-navigation__search-btn" href="#">{s:translate(key:'submit',default:'Search')}<span></span></a>
 		</div>
 		<div class="main-navigation__search-box js__main-navigation__search-box" >
 			<input type="search" id="inputText" name="{pluginNamespace}[q]" value="{q}" placeholder="{s:translate(key:'submit',default:'Search')}" data-search="searchSuggest" />

--- a/Resources/Private/Templates/FluidStyledContent/LanguageMenuStandard.html
+++ b/Resources/Private/Templates/FluidStyledContent/LanguageMenuStandard.html
@@ -5,7 +5,7 @@
     <div class="header-top__language-menu">
         <f:for each="{languages}" as="language">
             <f:if condition="{language.active}">
-                <a class="header-top__language-menu-btn js__header-top__language-menu-btn" href="/#">
+                <a class="header-top__language-menu-btn js__header-top__language-menu-btn" href="#">
                     <span class="main-flag-icon flag-icon flag-icon-{language.flagIdentifier}"></span>
                     <f:if condition="{theme:constant(constant:'themes.configuration.elem.status.showHeaderTopLangLabel')}">
                         <span class="main-flag-language flag-language">{f:translate(key:'languageMenu_label', extensionName:'ThemeT3kit')}</span>


### PR DESCRIPTION
[BUGFIX]
- If search button is clicked (in header-top or main-navigation) before js is loaded, user is sent to index-page.
- Similar fix for language-menu-btn.
- Removal of double attribute (data-search) in tag.