### PR TITLE
[BUGFIX] Main Navigation dropdown hover flickering between dropdowns.

### DIFF
--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -632,7 +632,6 @@
   transform-origin: top;
   transform: scale(1, 0);
   transition: transform 0.2s linear, opacity 0.2s linear, visibility 0.2s linear, max-height 0.2s linear;
-  z-index: 3000;
 }
 @media (max-width: 991px) {
   ._open-mobile-dropdown > .main-navigation__sub-item-list {

--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -817,6 +817,7 @@
     visibility: visible;
     opacity: 1;
     transform: translate3d(0, 0, 0);
+    z-index: 3000;
   }
   .touch .main-navigation__item._sub .main-navigation__open-sub-menu-link:before {
     /* use !important to prevent issues with browser extensions that change fonts */

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -3150,6 +3150,7 @@
         opacity: 1;
         -webkit-transform: translate3d(0, 0, 0);
         transform: translate3d(0, 0, 0);
+        z-index: 3000;
     }
 
     .touch .main-navigation__item._sub .main-navigation__open-sub-menu-link:before {

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -2954,7 +2954,6 @@
     transform: scale(1, 0);
     transition: -webkit-transform 0.2s linear, opacity 0.2s linear, visibility 0.2s linear, max-height 0.2s linear;
     transition: transform 0.2s linear, opacity 0.2s linear, visibility 0.2s linear, max-height 0.2s linear;
-    z-index: 3000;
 }
 
 @media (max-width: @screen-sm-max) {

--- a/felayout_t3kit/dev/styles/main/header/header.less
+++ b/felayout_t3kit/dev/styles/main/header/header.less
@@ -852,6 +852,7 @@
         opacity: 1;
         -webkit-transform: translate3d(0, 0, 0);
         transform: translate3d(0, 0, 0);
+        z-index: 3000;
     }
 
     .touch .main-navigation__item._sub .main-navigation__open-sub-menu-link:before {

--- a/felayout_t3kit/dev/styles/main/header/header.less
+++ b/felayout_t3kit/dev/styles/main/header/header.less
@@ -656,7 +656,6 @@
     transform: scale(1, 0);
     transition: -webkit-transform 0.2s linear, opacity 0.2s linear, visibility 0.2s linear, max-height 0.2s linear;
     transition: transform 0.2s linear, opacity 0.2s linear, visibility 0.2s linear, max-height 0.2s linear;
-    z-index: 3000;
 }
 
 @media (max-width: @screen-sm-max) {


### PR DESCRIPTION
See: https://github.com/t3kit/theme_t3kit/issues/511

Removing z-index 3000 from **.main-navigation__sub-item-list** makes the dropdown inherit the parent one ( **.main-navigation** ) at 2000.

From my testing it doesn't seem to affect any nearby content, but it's possible it would affect content with a very high (>1999) z-index.