### PR TITLE
[BUGFIX] searchBtn/searchBox toggle rewrite.

### DIFF
--- a/Resources/Public/css/main.js
+++ b/Resources/Public/css/main.js
@@ -136,17 +136,20 @@ jQuery(function ($) {
 
   $mainNavigationSearchBtn.on('click', function (e) {
     e.preventDefault()
-    $(this).toggleClass('_search-close-btn')
     $mainNavigationSearchBox.toggleClass('_search-box-visible')
     if ($mainNavigationSearchBox.hasClass('_search-box-visible')) {
       $mainNavigationSearchBox.find('input[type="search"]').focus()
+      $mainNavigationSearchBtn.addClass('_search-close-btn')
+      $mainNavigationSearchBoxOverlay.addClass('_search-box-overlay-visible')
+    } else {
+      $mainNavigationSearchBtn.removeClass('_search-close-btn')
+      $mainNavigationSearchBoxOverlay.removeClass('_search-box-overlay-visible')
     }
-    $mainNavigationSearchBoxOverlay.toggleClass('_search-box-overlay-visible')
   })
   $mainNavigationSearchBoxOverlay.on('click', function () {
-    $(this).toggleClass('_search-box-overlay-visible')
-    $mainNavigationSearchBtn.toggleClass('_search-close-btn')
-    $mainNavigationSearchBox.toggleClass('_search-box-visible')
+    $(this).removeClass('_search-box-overlay-visible')
+    $mainNavigationSearchBtn.removeClass('_search-close-btn')
+    $mainNavigationSearchBox.removeClass('_search-box-visible')
   })
   $languageMenuBtn.on('click', function (e) {
     e.preventDefault()

--- a/Resources/Public/less/main.js
+++ b/Resources/Public/less/main.js
@@ -136,17 +136,20 @@ jQuery(function ($) {
 
   $mainNavigationSearchBtn.on('click', function (e) {
     e.preventDefault()
-    $(this).toggleClass('_search-close-btn')
     $mainNavigationSearchBox.toggleClass('_search-box-visible')
     if ($mainNavigationSearchBox.hasClass('_search-box-visible')) {
       $mainNavigationSearchBox.find('input[type="search"]').focus()
+      $mainNavigationSearchBtn.addClass('_search-close-btn')
+      $mainNavigationSearchBoxOverlay.addClass('_search-box-overlay-visible')
+    } else {
+      $mainNavigationSearchBtn.removeClass('_search-close-btn')
+      $mainNavigationSearchBoxOverlay.removeClass('_search-box-overlay-visible')
     }
-    $mainNavigationSearchBoxOverlay.toggleClass('_search-box-overlay-visible')
   })
   $mainNavigationSearchBoxOverlay.on('click', function () {
-    $(this).toggleClass('_search-box-overlay-visible')
-    $mainNavigationSearchBtn.toggleClass('_search-close-btn')
-    $mainNavigationSearchBox.toggleClass('_search-box-visible')
+    $(this).removeClass('_search-box-overlay-visible')
+    $mainNavigationSearchBtn.removeClass('_search-close-btn')
+    $mainNavigationSearchBox.removeClass('_search-box-visible')
   })
   $languageMenuBtn.on('click', function (e) {
     e.preventDefault()

--- a/felayout_t3kit/dev/js/main/header/header.js
+++ b/felayout_t3kit/dev/js/main/header/header.js
@@ -134,17 +134,20 @@ jQuery(function ($) {
 
   $mainNavigationSearchBtn.on('click', function (e) {
     e.preventDefault()
-    $(this).toggleClass('_search-close-btn')
     $mainNavigationSearchBox.toggleClass('_search-box-visible')
     if ($mainNavigationSearchBox.hasClass('_search-box-visible')) {
       $mainNavigationSearchBox.find('input[type="search"]').focus()
+      $mainNavigationSearchBtn.addClass('_search-close-btn')
+      $mainNavigationSearchBoxOverlay.addClass('_search-box-overlay-visible')
+    } else {
+      $mainNavigationSearchBtn.removeClass('_search-close-btn')
+      $mainNavigationSearchBoxOverlay.removeClass('_search-box-overlay-visible')
     }
-    $mainNavigationSearchBoxOverlay.toggleClass('_search-box-overlay-visible')
   })
   $mainNavigationSearchBoxOverlay.on('click', function () {
-    $(this).toggleClass('_search-box-overlay-visible')
-    $mainNavigationSearchBtn.toggleClass('_search-close-btn')
-    $mainNavigationSearchBox.toggleClass('_search-box-visible')
+    $(this).removeClass('_search-box-overlay-visible')
+    $mainNavigationSearchBtn.removeClass('_search-close-btn')
+    $mainNavigationSearchBox.removeClass('_search-box-visible')
   })
   $languageMenuBtn.on('click', function (e) {
     e.preventDefault()


### PR DESCRIPTION
See: https://github.com/t3kit/theme_t3kit/issues/505

Since mainNavigationSearchBtn and mainNavigationSearchBox are used in both HeaderTop and HeaderMainMenu (main-navigation) they can both potentially be activated. I adjusted the js so they both keep the same class-states and doesn't go out of sync with what is expanded or not. It's also handled correctly when clicking the search-overlay.

Typoscript constant for testing:
**themes.configuration.elem.status.showHeaderTopSearch = 1
themes.configuration.elem.status.showHeaderMainMenuSearch = 1**

- Initial state
![1_default_state](https://user-images.githubusercontent.com/12510409/55963836-d4a3a680-5c73-11e9-8190-f095f8142a21.png)

- Search open
![2_search_open](https://user-images.githubusercontent.com/12510409/55963845-d8372d80-5c73-11e9-8d9d-5a2b84dbb388.png)

- Search closed again.
![3_search_closed](https://user-images.githubusercontent.com/12510409/55963852-dbcab480-5c73-11e9-8deb-964cf22af8f7.png)

