### PR TITLE
[BUGFIX] language menu in main-nav alignment when using dropdownColumns

### DIFF
--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -221,11 +221,10 @@
   list-style-type: none;
   padding: 0;
   position: absolute;
-  width: 100%;
-  right: 0;
-  left: auto;
   top: 0;
   background: #fff;
+  left: 0;
+  right: 0;
   z-index: 4000;
   text-align: right;
   padding-right: 50px;
@@ -233,6 +232,18 @@
   visibility: hidden;
   transition: opacity 0.3s 0s, visibility 0s 0.3s;
   border-bottom: 1px solid #ebf3f6;
+}
+@media (min-width: 992px) {
+  .header-top__language-menu-box {
+    left: calc((100% - 970px) / 2);
+    right: calc((100% - 970px) / 2);
+  }
+}
+@media (min-width: 1200px) {
+  .header-top__language-menu-box {
+    left: calc((100% - 1170px) / 2);
+    right: calc((100% - 1170px) / 2);
+  }
 }
 .header-top__language-menu-box-close-btn:after,
 .header-top__language-menu-box-close-btn:before {
@@ -426,7 +437,6 @@
   line-height: 60px;
 }
 .main-navigation .header-top__language-menu-box {
-  width: 100%;
   height: 100%;
   background-color: #2b2b2b;
 }

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -2435,12 +2435,10 @@
     list-style-type: none;
     padding: 0;
     position: absolute;
-    width: 100%;
-    right: 0;
-    left: auto;
     top: 0;
     background: @header-top-bg-color;
-    // background-color: @header-info-background;
+    left: 0;
+    right: 0;
     z-index: 4000;
     text-align: right;
     padding-right: 50px;
@@ -2448,6 +2446,16 @@
     visibility: hidden;
     transition: opacity 0.3s 0s, visibility 0s 0.3s;
     border-bottom: 1px solid @border-color;
+
+    @media (min-width: @screen-md-min) {
+        left: calc(~"(100% - 970px) / 2");
+        right: calc(~"(100% - 970px) / 2");
+    }
+
+    @media (min-width: @screen-lg-min) {
+        left: calc(~"(100% - 1170px) / 2");
+        right: calc(~"(100% - 1170px) / 2");
+    }
 }
 
 .header-top__language-menu-box-close-btn:after,
@@ -2690,7 +2698,6 @@
 }
 
 .main-navigation .header-top__language-menu-box {
-    width: 100%;
     height: 100%;
     background-color: @nav-background-color;
 }

--- a/felayout_t3kit/dev/styles/main/header/header.less
+++ b/felayout_t3kit/dev/styles/main/header/header.less
@@ -137,12 +137,10 @@
     list-style-type: none;
     padding: 0;
     position: absolute;
-    width: 100%;
-    right: 0;
-    left: auto;
     top: 0;
     background: @header-top-bg-color;
-    // background-color: @header-info-background;
+    left: 0;
+    right: 0;
     z-index: 4000;
     text-align: right;
     padding-right: 50px;
@@ -150,6 +148,16 @@
     visibility: hidden;
     transition: opacity 0.3s 0s, visibility 0s 0.3s;
     border-bottom: 1px solid @border-color;
+
+    @media (min-width: @screen-md-min) {
+        left: calc(~"(100% - 970px) / 2");
+        right: calc(~"(100% - 970px) / 2");
+    }
+
+    @media (min-width: @screen-lg-min) {
+        left: calc(~"(100% - 1170px) / 2");
+        right: calc(~"(100% - 1170px) / 2");
+    }
 }
 
 .header-top__language-menu-box-close-btn:after,
@@ -392,7 +400,6 @@
 }
 
 .main-navigation .header-top__language-menu-box {
-    width: 100%;
     height: 100%;
     background-color: @nav-background-color;
 }


### PR DESCRIPTION
Fixes issue: https://github.com/t3kit/theme_t3kit/issues/507

The main issue with combining **dropdownColumns = 1** and **enableLangMenuInNavigation = 1** is that the container that the language-menu is placed in is not a bootstrap-container-width anymore. This is because the dropdown columns needs this condition for the dropdown menus to occupy the full viewport width.

Therefore the open language-menu covers the full width of the viewport. This fix constrains that to Bootstrap-limits but makes sure it still looks the way it did before in viewport widths < 992 px.

**Typoscript configuration used**
themes.configuration.isDevelopment = 1
themes.configuration.menu.main.enableLangMenuInNavigation = 1
themes.configuration.elem.status.showHeaderTopLangMenu = 1
themes.configuration.elem.status.showHeaderTopSearch = 0
themes.configuration.elem.status.showHeaderMainMenuSearch = 0
themes.configuration.elem.status.showHeaderTopLangLabel = 1

themes.configuration.menu.main.dropdownColumns = 1

**Screenshots:**
(note1: **showHeaderTopLangMenu = 1** is also enabled in the screenshots to have something to compare with)
(note2: the white border of the open language menu in main-navigation was fixed in another pull request, see https://github.com/t3kit/theme_t3kit/pull/502/files#diff-a496fbbc3421dda897c120fdffc0969eR2707 )

Desktop language menu closed before
![language_0_0_before](https://user-images.githubusercontent.com/12510409/56030256-ae861100-5d1c-11e9-922a-0ddc8641a50d.png)
Desktop language menu closed after
![language_0_1_after](https://user-images.githubusercontent.com/12510409/56030255-ae861100-5d1c-11e9-8408-424d7d5d5c5e.png)

Desktop language menu open before
![language_1_0_before](https://user-images.githubusercontent.com/12510409/56030254-ae861100-5d1c-11e9-9044-d5a86c38a7c9.png)
Desktop language menu open after
![language_1_1_after](https://user-images.githubusercontent.com/12510409/56030253-aded7a80-5d1c-11e9-9838-006d33dcf34d.png)

Desktop 2 language menu open before
![language_2_0_before](https://user-images.githubusercontent.com/12510409/56030252-aded7a80-5d1c-11e9-95cb-1e0f6c4bf8f6.png)
Desktop 2 language menu open after
![language_2_1_after](https://user-images.githubusercontent.com/12510409/56030251-aded7a80-5d1c-11e9-9ef3-c7ef9eabdf4f.png)

Tablet language menu open before
![language_3_0_before](https://user-images.githubusercontent.com/12510409/56030250-aded7a80-5d1c-11e9-94de-b9a6289dceb0.png)
Tablet language menu open after
![language_3_1_after](https://user-images.githubusercontent.com/12510409/56030249-ad54e400-5d1c-11e9-8d29-b9e335d07a6e.png)

Mobile language menu open before
![language_4_0_before](https://user-images.githubusercontent.com/12510409/56030248-ad54e400-5d1c-11e9-897e-f3d96f19ea55.png)
Mobile language menu open after
![language_4_1_after](https://user-images.githubusercontent.com/12510409/56030247-ad54e400-5d1c-11e9-9854-c3e631e9f0b8.png)
