### PR TITLE
[BUGFIX] Meta navigation hidden when using language menu in

### DIFF
--- a/Resources/Public/css/main.js
+++ b/Resources/Public/css/main.js
@@ -148,18 +148,24 @@ jQuery(function ($) {
     $mainNavigationSearchBtn.toggleClass('_search-close-btn')
     $mainNavigationSearchBox.toggleClass('_search-box-visible')
   })
+
   $languageMenuBtn.on('click', function (e) {
     e.preventDefault()
     $languageMenuBox.addClass('_language-menu-box-visible')
-    $languageMenuOverlay.toggleClass('_language-menu-box-overlay-visible')
-    $metaNavigationNav.addClass('hidden')
+    $languageMenuOverlay.addClass('_language-menu-box-overlay-visible')
+
+    // hide meta-navigation if showHeaderTopLangMenu = 1
+    if ($('.header-top .js__header-top__language-menu-box').length) {
+      $metaNavigationNav.addClass('hidden')
+    }
   })
   $languageMenuOverlay.on('click', function () {
-    $(this).toggleClass('_language-menu-box-overlay-visible')
+    $(this).removeClass('_language-menu-box-overlay-visible')
     $languageMenuBox.removeClass('_language-menu-box-visible')
+    $metaNavigationNav.removeClass('hidden')
   })
   $languageMenuBoxCloseBtn.on('click', function () {
-    $languageMenuOverlay.toggleClass('_language-menu-box-overlay-visible')
+    $languageMenuOverlay.removeClass('_language-menu-box-overlay-visible')
     $languageMenuBox.removeClass('_language-menu-box-visible')
     $metaNavigationNav.removeClass('hidden')
   })

--- a/Resources/Public/less/main.js
+++ b/Resources/Public/less/main.js
@@ -148,18 +148,24 @@ jQuery(function ($) {
     $mainNavigationSearchBtn.toggleClass('_search-close-btn')
     $mainNavigationSearchBox.toggleClass('_search-box-visible')
   })
+
   $languageMenuBtn.on('click', function (e) {
     e.preventDefault()
     $languageMenuBox.addClass('_language-menu-box-visible')
-    $languageMenuOverlay.toggleClass('_language-menu-box-overlay-visible')
-    $metaNavigationNav.addClass('hidden')
+    $languageMenuOverlay.addClass('_language-menu-box-overlay-visible')
+
+    // hide meta-navigation if showHeaderTopLangMenu = 1
+    if ($('.header-top .js__header-top__language-menu-box').length) {
+      $metaNavigationNav.addClass('hidden')
+    }
   })
   $languageMenuOverlay.on('click', function () {
-    $(this).toggleClass('_language-menu-box-overlay-visible')
+    $(this).removeClass('_language-menu-box-overlay-visible')
     $languageMenuBox.removeClass('_language-menu-box-visible')
+    $metaNavigationNav.removeClass('hidden')
   })
   $languageMenuBoxCloseBtn.on('click', function () {
-    $languageMenuOverlay.toggleClass('_language-menu-box-overlay-visible')
+    $languageMenuOverlay.removeClass('_language-menu-box-overlay-visible')
     $languageMenuBox.removeClass('_language-menu-box-visible')
     $metaNavigationNav.removeClass('hidden')
   })

--- a/felayout_t3kit/dev/js/main/header/header.js
+++ b/felayout_t3kit/dev/js/main/header/header.js
@@ -146,18 +146,24 @@ jQuery(function ($) {
     $mainNavigationSearchBtn.toggleClass('_search-close-btn')
     $mainNavigationSearchBox.toggleClass('_search-box-visible')
   })
+
   $languageMenuBtn.on('click', function (e) {
     e.preventDefault()
     $languageMenuBox.addClass('_language-menu-box-visible')
-    $languageMenuOverlay.toggleClass('_language-menu-box-overlay-visible')
-    $metaNavigationNav.addClass('hidden')
+    $languageMenuOverlay.addClass('_language-menu-box-overlay-visible')
+
+    // hide meta-navigation if showHeaderTopLangMenu = 1
+    if ($('.header-top .js__header-top__language-menu-box').length) {
+      $metaNavigationNav.addClass('hidden')
+    }
   })
   $languageMenuOverlay.on('click', function () {
-    $(this).toggleClass('_language-menu-box-overlay-visible')
+    $(this).removeClass('_language-menu-box-overlay-visible')
     $languageMenuBox.removeClass('_language-menu-box-visible')
+    $metaNavigationNav.removeClass('hidden')
   })
   $languageMenuBoxCloseBtn.on('click', function () {
-    $languageMenuOverlay.toggleClass('_language-menu-box-overlay-visible')
+    $languageMenuOverlay.removeClass('_language-menu-box-overlay-visible')
     $languageMenuBox.removeClass('_language-menu-box-visible')
     $metaNavigationNav.removeClass('hidden')
   })


### PR DESCRIPTION
main-navigation. Doesn't reappear when clicking languageMenuOverlay to close it.

See: https://github.com/t3kit/theme_t3kit/issues/517

Both these issues are fixed now. First issue is fixed by only hiding meta-navigation if there's a language-menu in the top-header.

After fix (default state):
![language-open_1](https://user-images.githubusercontent.com/12510409/56040966-e2bafb00-5d37-11e9-90f6-ad24fa82868e.png)

After fix (opening language menu):
![language-open_2](https://user-images.githubusercontent.com/12510409/56040964-e2bafb00-5d37-11e9-8318-bde042c1a7d3.png)

