### PR TITLE
[BUGFIX] removal of colon in languageMenu_label

### DIFF
--- a/Resources/Private/Language/da.locallang.xlf
+++ b/Resources/Private/Language/da.locallang.xlf
@@ -11,8 +11,8 @@
                 <target>Du er her</target>
             </trans-unit>
             <trans-unit id="languageMenu_label" xml:space="preserve">
-                <source>Language:</source>
-                <target>Sprog:</target>
+                <source>Language</source>
+                <target>Sprog</target>
             </trans-unit>
             <trans-unit id="imprint_label" xml:space="preserve">
                 <source>Imprint</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -17,7 +17,7 @@
 				<source>Breadcrumb navigation</source>
 			</trans-unit>
 			<trans-unit id="languageMenu_label" xml:space="preserve">
-				<source>Language:</source>
+				<source>Language</source>
 			</trans-unit>
 			<trans-unit id="imprint_label" xml:space="preserve">
 				<source>Imprint</source>

--- a/Resources/Private/Language/nn.locallang.xlf
+++ b/Resources/Private/Language/nn.locallang.xlf
@@ -7,8 +7,8 @@
                 <target>Du er her</target>
             </trans-unit>
             <trans-unit id="languageMenu_label" xml:space="preserve">
-                <source>Språk:</source>
-                <target>Språk:</target>
+                <source>Språk</source>
+                <target>Språk</target>
             </trans-unit>
             <trans-unit id="imprint_label" xml:space="preserve">
                 <source>Om nettstedet</source>

--- a/Resources/Private/Language/no.locallang.xlf
+++ b/Resources/Private/Language/no.locallang.xlf
@@ -11,8 +11,8 @@
                 <target>Du er her</target>
             </trans-unit>
             <trans-unit id="languageMenu_label" xml:space="preserve">
-                <source>Language:</source>
-                <target>Språk:</target>
+                <source>Language</source>
+                <target>Språk</target>
             </trans-unit>
             <trans-unit id="imprint_label" xml:space="preserve">
                 <source>Imprint</source>


### PR DESCRIPTION
See: https://github.com/t3kit/theme_t3kit/issues/519

Before:
![Selection_349](https://user-images.githubusercontent.com/12510409/56045689-f9fee600-5d41-11e9-92d5-4464fb5c8cda.png)

After:
![Selection_347](https://user-images.githubusercontent.com/12510409/56045600-cf149200-5d41-11e9-8a87-f951f1dcab51.png)
