### PR TITLE
[BUGFIX] ie11 and edge social-icons underline fix

### DIFF
--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -7158,6 +7158,16 @@ div.awesomplete li[aria-selected="true"] mark {
         & > .icons:after {
             border-color: fade(@social-icons-hover-color, 50%);
         }
+
+        // ie11 and edge fix for underline on icon - text-decoration has to be styled before it can be unstyled
+        & > .icons:before when not (@link-hover-decoration = none) {
+            text-decoration: @link-hover-decoration;
+        }
+
+        & > .icons:before when not (@link-hover-decoration = none) {
+            text-decoration: none;
+        }
+        // end fix
     }
 }
 

--- a/felayout_t3kit/dev/styles/main/contentElements/socialIcons.less
+++ b/felayout_t3kit/dev/styles/main/contentElements/socialIcons.less
@@ -49,6 +49,16 @@
         & > .icons:after {
             border-color: fade(@social-icons-hover-color, 50%);
         }
+
+        // ie11 and edge fix for underline on icon - text-decoration has to be styled before it can be unstyled
+        & > .icons:before when not (@link-hover-decoration = none) {
+            text-decoration: @link-hover-decoration;
+        }
+
+        & > .icons:before when not (@link-hover-decoration = none) {
+            text-decoration: none;
+        }
+        // end fix
     }
 }
 


### PR DESCRIPTION
If **@link-hover-decoration** in **felayout/_t3kit/dev/styles/customVariables.less** is underline (or anything else than none) this will create underlined icons on social icons in IE11 / Edge. I have added a fix that is only applied if @link-hover-decoration is not the default "none".

Tested in Win 10, Edge 18 and IE11

**IE11, Win 10 Before:**
![win10_ie11_before_header](https://user-images.githubusercontent.com/12510409/56200539-4c404f80-603f-11e9-9a8c-03ca7e33e7a9.png)

![win10_ie11_before_footer](https://user-images.githubusercontent.com/12510409/56200540-4c404f80-603f-11e9-8448-af1e64e818f1.png)

**IE11, Win 10 After**
![win10_ie11_after_header](https://user-images.githubusercontent.com/12510409/56200541-4c404f80-603f-11e9-9ca9-44e2e9229e83.png)

![win10_ie11_after_footer](https://user-images.githubusercontent.com/12510409/56200543-4c404f80-603f-11e9-9e00-d20cbd1582ec.png)



