### PR TITLE
[BUGFIX] iconTextButton Header with multiple lines has uneven distances.

### DIFF
--- a/Resources/Public/css/main.css
+++ b/Resources/Public/css/main.css
@@ -2821,11 +2821,13 @@ div.awesomplete li[aria-selected="true"] mark {
   margin: 0 -15px;
 }
 .icon-text-btn__icon {
+  float: left;
+  margin-top: -0.5em;
   padding: 10px;
   border: 2px solid #cbe9f3;
   border-radius: 50%;
   color: #50b4d8;
-  margin-right: 10px;
+  margin-right: 16px;
   margin-bottom: 4px;
   display: inline-block;
 }
@@ -2860,6 +2862,14 @@ div.awesomplete li[aria-selected="true"] mark {
 }
 .icon-text-btn__p {
   margin-bottom: 18px;
+}
+.icon-text-btn__header {
+  padding-top: 0.5em;
+}
+.icon-text-btn__header:after {
+  display: block;
+  content: "";
+  clear: both;
 }
 .icon-text-btn__sham-link {
   color: #50b4d8;

--- a/Resources/Public/less/main.less
+++ b/Resources/Public/less/main.less
@@ -5548,11 +5548,13 @@ div.awesomplete li[aria-selected="true"] mark {
 }
 
 .icon-text-btn__icon {
+    float: left;
+    margin-top: -0.5em;
     padding: 10px;
     border: 2px solid tint(@main-color, 70%);
     border-radius: 50%;
     color: @main-color;
-    margin-right: 10px;
+    margin-right: 16px;
     margin-bottom: 4px;
     display: inline-block;
 }
@@ -5583,6 +5585,16 @@ div.awesomplete li[aria-selected="true"] mark {
 
 .icon-text-btn__p {
     margin-bottom: 18px;
+}
+
+.icon-text-btn__header {
+    padding-top: 0.5em;
+
+    &:after {
+        display: block;
+        content: "";
+        clear: both;
+    }
 }
 
 .icon-text-btn__sham-link {

--- a/felayout_t3kit/dev/styles/main/contentElements/leftIconTextButton.less
+++ b/felayout_t3kit/dev/styles/main/contentElements/leftIconTextButton.less
@@ -10,11 +10,13 @@
 }
 
 .icon-text-btn__icon {
+    float: left;
+    margin-top: -0.5em;
     padding: 10px;
     border: 2px solid tint(@main-color, 70%);
     border-radius: 50%;
     color: @main-color;
-    margin-right: 10px;
+    margin-right: 16px;
     margin-bottom: 4px;
     display: inline-block;
 }
@@ -45,6 +47,16 @@
 
 .icon-text-btn__p {
     margin-bottom: 18px;
+}
+
+.icon-text-btn__header {
+    padding-top: 0.5em;
+
+    &:after {
+        display: block;
+        content: "";
+        clear: both;
+    }
 }
 
 .icon-text-btn__sham-link {


### PR DESCRIPTION
Potential fix for #437 .

All it does is floating the icon (and compensates margin / padding so it looks just like before with 1 liner headers). Tested in Firefox, Chrome in Linux and IE11/Edge in Win10. It doesn't really fix any of the other issues like the alignment of the icon compared to the number of lines in the text, it's better to redesign the element for t3kit9.

These gifs shows before / after:

![iconTextButtonInvalidDistance2](https://user-images.githubusercontent.com/12510409/56807141-3d6f4f00-682e-11e9-9c41-6198b9a7f434.gif)

![iconTextButtonInvalidDistance](https://user-images.githubusercontent.com/12510409/56807142-3d6f4f00-682e-11e9-8c17-d0de0730f85f.gif)
