### PR TITLE
[!!!][BUGFIX] BigIconTextButton + ImageTextLink had 'btn btn-default' classes when disableWholeAreaLInk enabled

### DIFF
--- a/Resources/Private/Templates/ContentElements/BigIconTextButton.html
+++ b/Resources/Private/Templates/ContentElements/BigIconTextButton.html
@@ -4,6 +4,15 @@
 <f:section name="Header" />
 <f:section name="Main">
 <!-- theme_t3kit: Templates/ContentElements/BigIconTextButton.html [begin] -->
+	<f:comment>
+		<!--
+			Use a variable to set anchor class.
+			Leave empty if both disableWholeAreaLink and btnAsLink aren't set
+			Don't want classes btn btn-default when link is on "whole area"
+		-->
+	</f:comment>
+	<f:variable name="anchorClass">{f:if(condition: '{settings.disableWholeAreaLink} == 1 && {settings.btnAsLink} != 1' , then: ' btn btn-default', else: '')}</f:variable>
+
 	<div class="big-icon-text-btn__wrp">
 		<div class="big-icon-text-btn{f:if(condition: settings.disableWholeAreaLink, then: '', else: ' _whole-area-link')}">
 			<f:if condition="{settings.iconClass}">
@@ -25,10 +34,10 @@
 			<f:if condition="{data.header_link}">
 				<f:if condition="{data.subheader}">
 					<f:then>
-						<f:link.typolink parameter="{data.header_link}" class="big-icon-text-btn__link {f:if(condition: settings.btnAsLink, then: '', else: 'btn btn-default')}">{data.subheader}</f:link.typolink>
+						<f:link.typolink parameter="{data.header_link}" class="big-icon-text-btn__link{anchorClass}">{data.subheader}</f:link.typolink>
 					</f:then>
 					<f:else>
-						<f:link.typolink parameter="{data.header_link}" class="big-icon-text-btn__link {f:if(condition: settings.btnAsLink, then: '', else: 'btn btn-default')}">{data.header}</f:link.typolink>
+						<f:link.typolink parameter="{data.header_link}" class="big-icon-text-btn__link{anchorClass}">{data.header}</f:link.typolink>
 					</f:else>
 				</f:if>
 			</f:if>

--- a/Resources/Private/Templates/ContentElements/ImageTextLink.html
+++ b/Resources/Private/Templates/ContentElements/ImageTextLink.html
@@ -4,6 +4,15 @@
 <f:section name="Header" />
 <f:section name="Main">
 <!-- theme_t3kit: Templates/ContentElements/ImageTextLink.html [begin] -->
+	<f:comment>
+		<!--
+			Use a variable to set anchor class.
+			Leave empty if both disableWholeAreaLink and btnAsLink aren't set
+			Don't want classes btn btn-default when link is on "whole area"
+		-->
+	</f:comment>
+	<f:variable name="anchorClass">{f:if(condition: '{settings.disableWholeAreaLink} == 1 && {settings.btnAsLink} != 1' , then: ' btn btn-default', else: '')}</f:variable>
+
 	<div class="img-text-link__wrp">
 		<div class="img-text-link {f:if(condition: settings.disableWholeAreaLink, then: '', else: '_whole-area-link')} {f:if(condition: '{settings.hoverEffect} == 0', then: '', else: '_hover-{settings.hoverEffect}')}">
 			<f:if condition="{image}">
@@ -49,10 +58,10 @@
 			<f:if condition="{data.header_link}">
 				<f:if condition="{data.subheader}">
 					<f:then>
-						<f:link.typolink parameter="{data.header_link}" title="{data.subheader}" class="img-text-link__link {f:if(condition: settings.linkAsBtn, then: 'btn btn-default', else: '')}"> {data.subheader}</f:link.typolink>
+						<f:link.typolink parameter="{data.header_link}" title="{data.subheader}" class="img-text-link__link{anchorClass}"> {data.subheader}</f:link.typolink>
 					</f:then>
 					<f:else>
-				 		<f:link.typolink parameter="{data.header_link}" title="{data.header}" class="img-text-link__link {f:if(condition: settings.linkAsBtn, then: 'btn btn-default', else: '')}"> {data.header}</f:link.typolink>
+				 		<f:link.typolink parameter="{data.header_link}" title="{data.header}" class="img-text-link__link{anchorClass}"> {data.header}</f:link.typolink>
 					</f:else>
 				</f:if>
 			</f:if>


### PR DESCRIPTION
Solution from IconTextButton used.

# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [ ] Contributing to t3kit: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md>
- [ ] Coding Rules: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [ ] Commit message conventions: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [X] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests
- [ ] [SECURITY] - To mark important updates, when evaluating when we should update older sites

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [X] Yes
- [ ] No

It could possibly affect styling in subtheme, but that styling would probably be there to fix the issue in the first case (btn, btn-default classes where there shouldn't be).

## Description

BigIconTextButton and ImageTextLink had 'btn btn-default' classes on link even if disableWholeAreaLink was 1 - which is bad since the whole area will have button-styling when it shouldn't. Solution to solve this from IconTextButton was replicated.